### PR TITLE
MujintoCalculator

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/Scenario.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/Scenario.kt
@@ -35,6 +35,9 @@ import io.github.mee1080.umasim.scenario.uaf.UafScenarioEvents
 import io.github.mee1080.umasim.scenario.uaf.uafTrainingData
 import io.github.mee1080.umasim.scenario.ura.UraScenarioEvents
 import io.github.mee1080.umasim.scenario.ura.uraTrainingData
+import io.github.mee1080.umasim.scenario.mujinto.MujintoCalculator
+import io.github.mee1080.umasim.scenario.mujinto.MujintoScenarioEvents
+import io.github.mee1080.umasim.scenario.mujinto.mujintoTrainingData
 import io.github.mee1080.umasim.simulation2.AoharuMemberState
 import io.github.mee1080.umasim.simulation2.AoharuNotMemberState
 import io.github.mee1080.umasim.simulation2.ScenarioMemberState
@@ -191,6 +194,19 @@ enum class Scenario(
     ) {
         override fun memberState(card: SupportCard, guest: Boolean) = LegendMemberState(guest)
     },
+
+    MUJINTO(
+        scenarioNumber = 11,
+        displayName = "無人島シナリオ（仮）",
+        trainingData = mujintoTrainingData, // TODO: 無人島シナリオ
+        scenarioEvents = { MujintoScenarioEvents() }, // TODO: 無人島シナリオ
+        // Copied from URA scenario
+        turn = 78, // TODO: 無人島シナリオ
+        levelUpTurns = listOf(37, 38, 39, 40, 61, 62, 63, 64), // TODO: 無人島シナリオ
+        hasSecondTrainingStatus = false, // TODO: 無人島シナリオ
+        scenarioLink = emptySet(), // TODO: 無人島シナリオ
+        calculator = MujintoCalculator, // TODO: 無人島シナリオ
+    ),
 
     ;
 

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoCalculator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoCalculator.kt
@@ -1,0 +1,96 @@
+package io.github.mee1080.umasim.scenario.mujinto
+
+import io.github.mee1080.umasim.data.ExpectedStatus
+import io.github.mee1080.umasim.data.RaceEntry
+import io.github.mee1080.umasim.data.Status
+import io.github.mee1080.umasim.scenario.ScenarioCalculator
+import io.github.mee1080.umasim.simulation2.Action
+import io.github.mee1080.umasim.simulation2.Calculator
+import io.github.mee1080.umasim.simulation2.ScenarioActionParam
+import io.github.mee1080.umasim.simulation2.SimulationState
+
+// TODO: 無人島シナリオ固有の計算ロジックを実装する必要があれば、Defaultではなく独自のCalculatorを実装する
+object MujintoCalculator : ScenarioCalculator {
+    // TODO: 以下の各メソッドについて、無人島シナリオ固有の計算ロジックが必要な場合は実装する
+
+    override fun calcScenarioStatus(
+        info: Calculator.CalcInfo,
+        base: Status,
+        raw: ExpectedStatus,
+        friendTraining: Boolean,
+    ): Status {
+        // TODO: 無人島シナリオ固有のステータス計算があれば実装
+        return super.calcScenarioStatus(info, base, raw, friendTraining)
+    }
+
+    override fun calcBaseRaceStatus(
+        state: SimulationState,
+        race: RaceEntry,
+        goal: Boolean,
+    ): Status? {
+        // TODO: 無人島シナリオ固有のレースステータス計算があれば実装
+        return super.calcBaseRaceStatus(state, race, goal)
+    }
+
+    override fun applyScenarioRaceBonus(
+        state: SimulationState,
+        base: Status,
+    ): Status {
+        // TODO: 無人島シナリオ固有のレースボーナス適用があれば実装
+        return super.applyScenarioRaceBonus(state, base)
+    }
+
+    override fun raceScenarioActionParam(
+        state: SimulationState,
+        race: RaceEntry,
+        goal: Boolean,
+    ): ScenarioActionParam? {
+        // TODO: 無人島シナリオ固有のレースアクションパラメータがあれば実装
+        return super.raceScenarioActionParam(state, race, goal)
+    }
+
+    override fun predictSleep(
+        state: SimulationState,
+    ): Array<Action>? {
+        // TODO: 無人島シナリオ固有の睡眠予測があれば実装
+        return super.predictSleep(state)
+    }
+
+    override fun predictScenarioActionParams(
+        state: SimulationState,
+        baseActions: List<Action>,
+    ): List<Action> {
+        // TODO: 無人島シナリオ固有のアクションパラメータ予測があれば実装
+        return super.predictScenarioActionParams(state, baseActions)
+    }
+
+    override fun predictScenarioAction(
+        state: SimulationState,
+        goal: Boolean,
+    ): Array<Action> {
+        // TODO: 無人島シナリオ固有のアクション予測があれば実装
+        return super.predictScenarioAction(state, goal)
+    }
+
+    override fun normalRaceBlocked(
+        state: SimulationState,
+    ): Boolean {
+        // TODO: 無人島シナリオ固有の通常レースブロック条件があれば実装
+        return super.normalRaceBlocked(state)
+    }
+
+    override fun updateScenarioTurn(
+        state: SimulationState,
+    ): SimulationState {
+        // TODO: 無人島シナリオ固有のターン更新処理があれば実装
+        return super.updateScenarioTurn(state)
+    }
+
+    override fun updateOnAddStatus(
+        state: SimulationState,
+        status: Status,
+    ): SimulationState {
+        // TODO: 無人島シナリオ固有のステータス加算時処理があれば実装
+        return super.updateOnAddStatus(state, status)
+    }
+}

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoScenarioEvents.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoScenarioEvents.kt
@@ -1,0 +1,8 @@
+package io.github.mee1080.umasim.scenario.mujinto
+
+import io.github.mee1080.umasim.scenario.CommonScenarioEvents
+
+// TODO: 無人島シナリオ固有のイベント処理を実装
+class MujintoScenarioEvents : CommonScenarioEvents() {
+    // TODO: 必要に応じてメソッドをオーバーライドし、無人島シナリオ固有の処理を実装する
+}

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/mujintoTrainingData.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/mujintoTrainingData.kt
@@ -1,0 +1,6 @@
+package io.github.mee1080.umasim.scenario.mujinto
+
+import io.github.mee1080.umasim.data.TrainingBase
+
+// TODO: 無人島シナリオのトレーニングデータを定義
+val mujintoTrainingData: List<TrainingBase> = emptyList()

--- a/core/src/test/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoCalculatorTest.kt
+++ b/core/src/test/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoCalculatorTest.kt
@@ -1,0 +1,71 @@
+package io.github.mee1080.umasim.scenario.mujinto
+
+import org.junit.jupiter.api.Test
+// import io.github.mee1080.umasim.data.ExpectedStatus // Uncomment if needed for tests
+// import io.github.mee1080.umasim.data.RaceEntry // Uncomment if needed for tests
+// import io.github.mee1080.umasim.data.Status // Uncomment if needed for tests
+// import io.github.mee1080.umasim.simulation2.Action // Uncomment if needed for tests
+// import io.github.mee1080.umasim.simulation2.Calculator // Uncomment if needed for tests
+// import io.github.mee1080.umasim.simulation2.ScenarioActionParam // Uncomment if needed for tests
+// import io.github.mee1080.umasim.simulation2.SimulationState // Uncomment if needed for tests
+
+class MujintoCalculatorTest {
+
+    // TODO: 必要に応じてMujintoCalculatorのインスタンスを初期化
+
+    @Test
+    fun calcScenarioStatus_test() {
+        // TODO: 無人島シナリオにおける calcScenarioStatus の具体的なテストケースを記述
+        // 例: val calculator = MujintoCalculator
+        //     val info = Calculator.CalcInfo(...)
+        //     val baseStatus = Status(...)
+        //     val rawStatus = ExpectedStatus(...)
+        //     val result = calculator.calcScenarioStatus(info, baseStatus, rawStatus, false)
+        //     assertEquals(expected, result) // JUnitのassertEqualsなどを使用
+    }
+
+    @Test
+    fun calcBaseRaceStatus_test() {
+        // TODO: 無人島シナリオにおける calcBaseRaceStatus の具体的なテストケースを記述
+    }
+
+    @Test
+    fun applyScenarioRaceBonus_test() {
+        // TODO: 無人島シナリオにおける applyScenarioRaceBonus の具体的なテストケースを記述
+    }
+
+    @Test
+    fun raceScenarioActionParam_test() {
+        // TODO: 無人島シナリオにおける raceScenarioActionParam の具体的なテストケースを記述
+    }
+
+    @Test
+    fun predictSleep_test() {
+        // TODO: 無人島シナリオにおける predictSleep の具体的なテストケースを記述
+    }
+
+    @Test
+    fun predictScenarioActionParams_test() {
+        // TODO: 無人島シナリオにおける predictScenarioActionParams の具体的なテストケースを記述
+    }
+
+    @Test
+    fun predictScenarioAction_test() {
+        // TODO: 無人島シナリオにおける predictScenarioAction の具体的なテストケースを記述
+    }
+
+    @Test
+    fun normalRaceBlocked_test() {
+        // TODO: 無人島シナリオにおける normalRaceBlocked の具体的なテストケースを記述
+    }
+
+    @Test
+    fun updateScenarioTurn_test() {
+        // TODO: 無人島シナリオにおける updateScenarioTurn の具体的なテストケースを記述
+    }
+
+    @Test
+    fun updateOnAddStatus_test() {
+        // TODO: 無人島シナリオにおける updateOnAddStatus の具体的なテストケースを記述
+    }
+}


### PR DESCRIPTION
This commit introduces the basic test structure for `MujintoCalculator`.

Key changes:
- Created the directory `core/src/test/kotlin/io/github/mee1080/umasim/scenario/mujinto/`.
- Added `MujintoCalculatorTest.kt` with placeholder test methods for each public method in `MujintoCalculator`.
- Each test method includes a `// TODO` comment to indicate where specific test cases should be implemented.