### PR TITLE
feat: Implement initial framework for Mujinto scenario

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/Scenario.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/Scenario.kt
@@ -196,17 +196,29 @@ enum class Scenario(
     },
 
     MUJINTO(
-        scenarioNumber = 11,
-        displayName = "無人島シナリオ（仮）",
-        trainingData = mujintoTrainingData, // TODO: 無人島シナリオ
-        scenarioEvents = { MujintoScenarioEvents() }, // TODO: 無人島シナリオ
-        // Copied from URA scenario
-        turn = 78, // TODO: 無人島シナリオ
-        levelUpTurns = listOf(37, 38, 39, 40, 61, 62, 63, 64), // TODO: 無人島シナリオ
-        hasSecondTrainingStatus = false, // TODO: 無人島シナリオ
-        scenarioLink = emptySet(), // TODO: 無人島シナリオ
-        calculator = MujintoCalculator, // TODO: 無人島シナリオ
-    ),
+        scenarioNumber = 11, // Assuming next available number
+        displayName = "無人島へようこそ -DESIGN YOUR ISLAND-", // From memo title
+        trainingData = mujintoTrainingData,
+        scenarioEvents = { MujintoScenarioEvents() },
+        // Values below are placeholders or based on common patterns, update with actual data.
+        turn = 78, // Standard turn count, confirm if different for Mujinto
+        // levelUpTurns: Unknown, typically related to summer training camps if applicable
+        levelUpTurns = listOf(37, 38, 39, 40, 61, 62, 63, 64), // Placeholder from URA
+        guestMember = true, // Tucker Bligh is a new friend card, implies guest mechanics
+        hasSecondTrainingStatus = true, // Common for newer scenarios, "Island Training" might use it
+        scenarioLink = setOf(
+            "タマモクロス",
+            "メジロライアン",
+            "アイネスフウジン",
+            "ゴールドシチー",
+            "サクラチヨノオー",
+            "タッカーブライン"
+        ), // From mujinto_memo.md
+        calculator = MujintoCalculator,
+    ) {
+        override fun memberState(card: SupportCard, guest: Boolean) = io.github.mee1080.umasim.scenario.mujinto.MujintoMemberState() // Ensure MujintoMemberState is used
+        override fun memberState(member: TeamMemberData) = io.github.mee1080.umasim.scenario.mujinto.MujintoMemberState()
+    },
 
     ;
 

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoCalculator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoCalculator.kt
@@ -3,15 +3,13 @@ package io.github.mee1080.umasim.scenario.mujinto
 import io.github.mee1080.umasim.data.ExpectedStatus
 import io.github.mee1080.umasim.data.RaceEntry
 import io.github.mee1080.umasim.data.Status
+import io.github.mee1080.umasim.data.StatusType
 import io.github.mee1080.umasim.scenario.ScenarioCalculator
-import io.github.mee1080.umasim.simulation2.Action
-import io.github.mee1080.umasim.simulation2.Calculator
-import io.github.mee1080.umasim.simulation2.ScenarioActionParam
-import io.github.mee1080.umasim.simulation2.SimulationState
+import io.github.mee1080.umasim.simulation2.*
+import io.github.mee1080.umasim.utility.applyIf
+import kotlin.math.min
 
-// TODO: 無人島シナリオ固有の計算ロジックを実装する必要があれば、Defaultではなく独自のCalculatorを実装する
 object MujintoCalculator : ScenarioCalculator {
-    // TODO: 以下の各メソッドについて、無人島シナリオ固有の計算ロジックが必要な場合は実装する
 
     override fun calcScenarioStatus(
         info: Calculator.CalcInfo,
@@ -19,8 +17,51 @@ object MujintoCalculator : ScenarioCalculator {
         raw: ExpectedStatus,
         friendTraining: Boolean,
     ): Status {
-        // TODO: 無人島シナリオ固有のステータス計算があれば実装
-        return super.calcScenarioStatus(info, base, raw, friendTraining)
+        val mujintoStatus = info.mujintoStatus ?: return Status()
+        var scenarioBonus = Status()
+
+        // Apply facility bonuses
+        // TODO: Refine this based on how "島トレ効果" and specific facility level effects work.
+        // This is a very simplified placeholder.
+        val speedFacility = mujintoStatus.facilities[FacilityType.SPEED]
+        if (speedFacility != null && speedFacility.level > 0) {
+            // Example: "スピードLv1: 島トレ・島スピードにスピボ1", "島スピードのトレ効果5%"
+            // Assuming direct status bonus for now if it's a speed training.
+            if (info.training.type == StatusType.SPEED) {
+                scenarioBonus += Status(speed = speedFacility.level * 2) // Placeholder
+            }
+        }
+        // TODO: Add similar logic for STAMINA, POWER, GUTS, WISDOM facilities.
+        // TODO: Implement effects of SPECIAL facilities.
+
+        // Apply "Island Training" (島トレ) specific bonuses if this training is an island training.
+        // This requires identifying if the current `info.training` is an "Island Training".
+        // We might need a new Action type or a flag in `Training` action.
+        // For now, assume a generic training.
+        if (isIslandTraining(info.training)) {
+            // TODO: Implement "Island Training" stat calculation.
+            // "全パラメータアップ"
+            // "無人島の各施設にサポカとゲストを配置、得意トレの施設なら友情"
+            // "サポカタイプに応じた能力が上がる、得意トレがバラバラの方が強い？"
+            // This will be complex and needs access to facility levels, support card placements for island training.
+            scenarioBonus += Status(speed = 5, stamina = 5, power = 5, guts = 5, wisdom = 5) // Placeholder
+        }
+
+        // TODO: Apply bonuses from "Evaluation Meetings" (評価会) if any are active.
+        // "通常トレ効果アップありそう"
+
+        // The `mujinto_memo.md` mentions "ゲストあり、最大11人？" for training.
+        // This might influence existing `Calculator.calcTrainingStatus` through member count or specific guest mechanics.
+        // For now, this is handled by the core calculator, but might need adjustments.
+
+        return scenarioBonus
+    }
+
+    // Helper to check if a training is an "Island Training" - needs proper implementation
+    private fun isIslandTraining(training: Training): Boolean {
+        // Placeholder: This needs a proper way to identify Island Training.
+        // Maybe a specific ActionParam or a new Action type.
+        return (training.actionParam as? MujintoActionParam)?.isIslandTraining ?: false
     }
 
     override fun calcBaseRaceStatus(
@@ -29,6 +70,11 @@ object MujintoCalculator : ScenarioCalculator {
         goal: Boolean,
     ): Status? {
         // TODO: 無人島シナリオ固有のレースステータス計算があれば実装
+        // "レース後能力アップ TODO" in memo.
+        // This might be a fixed bonus or depend on race performance/facilities.
+        if (goal) {
+            return Status(skillPt = 10) // Placeholder
+        }
         return super.calcBaseRaceStatus(state, race, goal)
     }
 
@@ -37,6 +83,7 @@ object MujintoCalculator : ScenarioCalculator {
         base: Status,
     ): Status {
         // TODO: 無人島シナリオ固有のレースボーナス適用があれば実装
+        // This could also be where "レース後能力アップ" is applied.
         return super.applyScenarioRaceBonus(state, base)
     }
 
@@ -53,6 +100,7 @@ object MujintoCalculator : ScenarioCalculator {
         state: SimulationState,
     ): Array<Action>? {
         // TODO: 無人島シナリオ固有の睡眠予測があれば実装
+        // Tucker Bligh outing effects might be relevant here if outings are predicted similarly to sleep.
         return super.predictSleep(state)
     }
 
@@ -60,17 +108,58 @@ object MujintoCalculator : ScenarioCalculator {
         state: SimulationState,
         baseActions: List<Action>,
     ): List<Action> {
-        // TODO: 無人島シナリオ固有のアクションパラメータ予測があれば実装
-        return super.predictScenarioActionParams(state, baseActions)
+        // This is where we might add `MujintoActionParam` for Island Training.
+        val mujintoStatus = state.mujintoStatus ?: return baseActions
+
+        return baseActions.map { action ->
+            when (action) {
+                is Training -> {
+                    // For now, no specific params for normal training, but could be added.
+                    // If Island Training is an option, it should be one of the `baseActions`
+                    // or generated here based on `mujintoStatus.islandTrainingTickets > 0`.
+                    action
+                }
+                // TODO: Add params for Tucker Bligh outings if they have choices.
+                else -> action
+            }
+        }
     }
 
     override fun predictScenarioAction(
         state: SimulationState,
         goal: Boolean,
     ): Array<Action> {
-        // TODO: 無人島シナリオ固有のアクション予測があれば実装
-        return super.predictScenarioAction(state, goal)
+        val mujintoStatus = state.mujintoStatus ?: return emptyArray()
+        val scenarioActions = mutableListOf<Action>()
+
+        // Predict "Island Training" (島トレ) if a ticket is available
+        if (mujintoStatus.islandTrainingTickets > 0) {
+            // TODO: Create a proper "IslandTraining" action.
+            // This needs to define how stats are gained, which depends on facility levels and support card placements.
+            // For now, a placeholder Training action with a special param.
+            // The actual stat calculation will happen in `calcScenarioStatus` when this action is chosen.
+            val islandTrainingAction = Training(
+                type = StatusType.SPEED, // Placeholder, actual Island Training affects all stats
+                level = 1, // Placeholder
+                base = Status(speed = 5, stamina = 5, power = 5, guts = 5, wisdom = 5), // Placeholder base gain
+                failureRate = 0,
+                turn = state.turn,
+                actionParam = MujintoActionParam(isIslandTraining = true)
+                // `member` for island training would be complex, involving all placed supports.
+            )
+            // scenarioActions.add(islandTrainingAction) // Needs a proper Action definition
+        }
+
+        // TODO: Predict "Facility Construction" (施設建設) actions.
+        // "建設計画で順番を選ぶ" - implies an action to choose/start construction.
+        // This would likely depend on `mujintoStatus.developmentPoints`.
+
+        // TODO: Predict Tucker Bligh outing actions if she's a friend card and outings are available.
+        // Her outings have choices, which would need to be modeled as different actions or results.
+
+        return scenarioActions.toTypedArray()
     }
+
 
     override fun normalRaceBlocked(
         state: SimulationState,
@@ -82,8 +171,18 @@ object MujintoCalculator : ScenarioCalculator {
     override fun updateScenarioTurn(
         state: SimulationState,
     ): SimulationState {
-        // TODO: 無人島シナリオ固有のターン更新処理があれば実装
-        return super.updateScenarioTurn(state)
+        var newState = state
+        // Apply Tucker Bligh's "次のターンに得意率アップ" effect
+        // This needs tracking of which support cards were affected.
+        // Could be stored in `MujintoMemberState` or a temporary list in `MujintoStatus`.
+        // TODO: Implement Tucker Bligh's next-turn specialty rate up.
+
+        // Handle construction progress if facilities are being built.
+        // "建設には発展Ptが必要"
+        // "建設進捗度が上がる 100Ptで1マス"
+        // This might be better handled in `afterAction` when development points are gained.
+
+        return super.updateScenarioTurn(newState)
     }
 
     override fun updateOnAddStatus(
@@ -93,4 +192,56 @@ object MujintoCalculator : ScenarioCalculator {
         // TODO: 無人島シナリオ固有のステータス加算時処理があれば実装
         return super.updateOnAddStatus(state, status)
     }
+
+    // --- Helper functions and specific logic for Mujinto ---
+
+    fun applyFacilityConstruction(state: SimulationState, facilityType: FacilityType, pointsSpent: Int): SimulationState {
+        val mujintoStatus = state.mujintoStatus ?: return state
+        val facility = mujintoStatus.facilities[facilityType] ?: return state
+
+        // Assuming 100 points for 1 "mass" of progress.
+        // Facility levels might require different amounts of "masses".
+        // TODO: Refine based on actual construction mechanics.
+        val newProgress = facility.constructionProgress + pointsSpent
+        var newLevel = facility.level
+        // Placeholder: assume each level needs 100 progress points (1 mass) for simplicity
+        val pointsPerLevel = 100
+        if (newProgress >= pointsPerLevel) {
+            // Level up logic
+            // newLevel = min(5, newLevel + newProgress / pointsPerLevel) // Max level 5
+            // facility.constructionProgress = newProgress % pointsPerLevel
+            // This needs more details on how levels and "masses" (マス) work.
+            // "Lv1～3：1マス、Lv4：2マス、Lv5：3マス"
+        } else {
+            // facility.constructionProgress = newProgress
+        }
+
+        // TODO: "建設2枠と5枠？で島トレ券を獲得し、同時に施設効果発動？"
+        // This implies tracking total construction "枠" (slots/masses) filled.
+
+        return state.updateMujintoStatus {
+            copy(
+                facilities = facilities.toMutableMap().apply {
+                    this[facilityType] = facility.copy(level = newLevel, constructionProgress = facility.constructionProgress)
+                },
+                developmentPoints = developmentPoints - pointsSpent // Assuming points are spent from total
+            )
+        }
+    }
+
+    // ActionParam for Mujinto specific actions like Island Training
+    data class MujintoActionParam(
+        val isIslandTraining: Boolean = false,
+        // TODO: Add other params like facility to construct, Tucker Bligh outing choice, etc.
+    ) : ScenarioActionParam(Scenario.MUJINTO)
 }
+
+// Extension property for easier access to MujintoStatus from SimulationState
+val SimulationState.mujintoStatus: MujintoStatus?
+    get() = scenarioStatus as? MujintoStatus
+
+// Extension property for easier access to MujintoMemberState from MemberState
+val MemberState.mujintoMemberState: MujintoMemberState?
+    get() = scenarioState as? MujintoMemberState
+
+[end of core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoCalculator.kt]

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoScenarioEvents.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoScenarioEvents.kt
@@ -1,8 +1,223 @@
 package io.github.mee1080.umasim.scenario.mujinto
 
-import io.github.mee1080.umasim.scenario.CommonScenarioEvents
+import io.github.mee1080.umasim.data.Status
+import io.github.mee1080.umasim.scenario.BaseScenarioEvents
+import io.github.mee1080.umasim.simulation2.*
+import io.github.mee1080.umasim.utility.applyIf
+import kotlin.math.min
 
-// TODO: 無人島シナリオ固有のイベント処理を実装
-class MujintoScenarioEvents : CommonScenarioEvents() {
-    // TODO: 必要に応じてメソッドをオーバーライドし、無人島シナリオ固有の処理を実装する
+class MujintoScenarioEvents : BaseScenarioEvents() {
+
+    override fun beforeSimulation(state: SimulationState): SimulationState {
+        val mujintoStatus = MujintoStatus()
+        return super.beforeSimulation(state).copy(scenarioStatus = mujintoStatus)
+    }
+
+    override fun afterAction(state: SimulationState, selector: ActionSelector): SimulationState {
+        var newState = super.afterAction(state, selector)
+        val mujintoStatus = newState.mujintoStatus ?: return newState
+        val action = state.history.lastOrNull()?.action ?: return newState // Get the action that just occurred
+
+        // Gain Development Points (発展Pt)
+        // "トレーニング、レース等で獲得（お休みは？）"
+        var developmentPointsGained = 0
+        when (action) {
+            is Training -> {
+                // TODO: Determine actual points based on training type/level/success
+                developmentPointsGained = if (action.result?.success == true) 20 else 5 // Placeholder
+                if ((action.actionParam as? MujintoCalculator.MujintoActionParam)?.isIslandTraining == true) {
+                    // Island training might consume a ticket
+                    newState = newState.updateMujintoStatus { copy(islandTrainingTickets = islandTrainingTickets - 1) }
+                    developmentPointsGained += 10 // Extra points for island training? Placeholder
+                }
+            }
+            is Race -> {
+                // TODO: Determine points based on race result/importance
+                developmentPointsGained = 30 // Placeholder
+            }
+            is Sleep -> {
+                // "お休みは？" - Assuming no points for sleep for now.
+                developmentPointsGained = 0
+            }
+            is Outing -> {
+                // Tucker Bligh outings: "共通：お出かけ後に発展ポイント"
+                // TODO: Determine specific points from Tucker Bligh outings
+                developmentPointsGained = 15 // Placeholder for generic outing, Tucker specific below
+            }
+            // TODO: Add other actions that might grant development points
+        }
+
+        if (developmentPointsGained > 0) {
+            newState = newState.updateMujintoStatus {
+                val newDevPoints = this.developmentPoints + developmentPointsGained
+                // Handle construction progress
+                // "建設進捗度が上がる 100Ptで1マス"
+                // This logic might be too simple. Construction might be an explicit action.
+                // For now, let's assume points directly contribute to some global progress or are just accumulated.
+                // Facility construction logic will be handled by specific actions or events.
+                copy(developmentPoints = newDevPoints)
+            }
+        }
+
+        // Handle Facility Construction Progress and Island Training Tickets
+        // "建設2枠と5枠？で島トレ券を獲得し、同時に施設効果発動？"
+        // This requires tracking "建設枠" (construction slots/masses).
+        // This is a placeholder for a more complex system.
+        // Let's assume every 200 development points globally might trigger something.
+        val totalMassesBuilt = mujintoStatus.developmentPoints / 100 // Simplified: 100 points = 1 mass
+        var ticketsToAdd = 0
+        var newEventFlags = mujintoStatus.eventFlags
+        if (totalMassesBuilt >= 2 && !mujintoStatus.eventFlags.contains("TicketAt2Masses")) {
+            ticketsToAdd = 1
+            newEventFlags = newEventFlags + "TicketAt2Masses"
+        }
+        if (totalMassesBuilt >= 5 && !mujintoStatus.eventFlags.contains("TicketAt5Masses")) {
+            ticketsToAdd = 1 // This would be the second ticket if the first was already gained.
+            newEventFlags = newEventFlags + "TicketAt5Masses"
+        }
+        if (ticketsToAdd > 0) {
+            newState = newState.updateMujintoStatus {
+                // "特別な期間を除き1枚のみ所有可能"
+                copy(
+                    islandTrainingTickets = min(1, this.islandTrainingTickets + ticketsToAdd),
+                    eventFlags = newEventFlags
+                )
+            }
+            // TODO: "同時に施設効果発動？" - Implement facility effect activation.
+        }
+
+
+        // Evaluation Meetings (評価会)
+        // "半年ごとに発生" (Turns: 12, 24, 36, 48, 60, 72 - assuming 2 turns per month)
+        val evaluationTurns = setOf(12, 24, 36, 48, 60) // Not at 72, as it's end of育成
+        if (evaluationTurns.contains(newState.turn)) {
+            // TODO: Implement evaluation logic
+            // "建設状況/発展Ptで評価"
+            // "通常トレ効果アップありそう"
+            // "ステータスアップ"
+            var statusBonus = Status()
+            var trainingEffectUp = 0 // Placeholder for %
+            val currentDevPoints = mujintoStatus.developmentPoints
+            val facilityLevels = mujintoStatus.facilities.values.sumOf { it.level }
+
+            if (currentDevPoints > 500 && facilityLevels > 5) { // Example high evaluation
+                statusBonus = Status(speed = 15, stamina = 15, power = 15, guts = 15, wisdom = 15, skillPt = 50)
+                trainingEffectUp = 10 // 10% training effect up
+            } else if (currentDevPoints > 200 && facilityLevels > 2) { // Example mid evaluation
+                statusBonus = Status(speed = 8, stamina = 8, power = 8, guts = 8, wisdom = 8, skillPt = 25)
+                trainingEffectUp = 5 // 5% training effect up
+            } else { // Example low evaluation
+                statusBonus = Status(speed = 3, stamina = 3, power = 3, guts = 3, wisdom = 3, skillPt = 10)
+            }
+            newState = newState.addStatus(statusBonus)
+            // TODO: Store and apply `trainingEffectUp` in MujintoStatus/Calculator
+            newState = newState.updateMujintoStatus {
+                copy(evaluationMeetingCount = evaluationMeetingCount + 1)
+                // Add a flag or a temporary buff for trainingEffectUp
+            }
+            // For logging/display purposes
+            // newState = newState.addEventMessage("Evaluation Meeting Completed! Gained bonus: $statusBonus, Training Effect +$trainingEffectUp%")
+        }
+
+        // Tucker Bligh Events
+        if (action is Outing && action.memberIndex == state.tuckerBlighIndex) { // Assuming tuckerBlighIndex is known
+            newState = handleTuckerBlighOuting(newState, selector, action)
+        }
+        if (action is Training && action.result?.success == true && state.tuckerBlighIndex != -1 && action.member.any{it.index == state.tuckerBlighIndex}) {
+             newState = handleTuckerBlighPostTraining(newState)
+        }
+
+        // Scenario Link Character Events
+        // TODO: Implement based on "シナリオリンク" in memo.
+        // This would involve checking if linked characters are in the deck and triggering their specific events/effects.
+
+        // Specific Turn-based Events from memo (if any, most are TODO)
+        // Example: newState.turn == X -> trigger specific event
+
+        return newState
+    }
+
+    private fun handleTuckerBlighPostTraining(state: SimulationState): SimulationState {
+        var newState = state
+        // "トレーニング後イベント: 絆+5、スタ+5、編成サポカ次ターン得意率20、大成功ならやる気+1"
+        newState = newState.addRelation(5, memberIndex = state.tuckerBlighIndex)
+        newState = newState.addStatus(Status(stamina = 5))
+        // TODO: Implement "編成サポカ次ターン得意率20" - This needs a mechanism to apply buffs to other cards for next turn.
+        // This could be a temporary list in MujintoStatus or individual flags in MujintoMemberState.
+        newState = newState.updateMujintoStatus { copy(tuckerSpecialtyBuffNextTurn = true, tuckerSpecialtyBuffNextTurnAmount = 20) }
+
+        // "大成功ならやる気+1" - How is "大成功" determined for a training event?
+        // Assuming a 10% chance for placeholder.
+        if (newState.random.nextInt(100) < 10) { // Placeholder for "大成功"
+            newState = newState.addStatus(Status(motivation = 1))
+        }
+        return newState
+    }
+
+    private suspend fun handleTuckerBlighOuting(state: SimulationState, selector: ActionSelector, outing: Outing): SimulationState {
+        var newState = state
+        // "共通：お出かけ後に発展ポイント" - Handled by general development point gain.
+        // Outing count is implicitly tracked by game state or could be in MujintoMemberState for Tucker.
+
+        // TODO: Determine which outing number this is. For now, assume it's known or passed.
+        // This likely needs a persistent counter for Tucker's outings.
+        val tuckerOutingCount = state.member[state.tuckerBlighIndex].outingCount // Assuming outingCount exists on member
+
+        when (tuckerOutingCount) {
+            // 1 -> { /* TODO: 1回目 */ }
+            // 2 -> { /* TODO: 2回目 */ }
+            3 -> {
+                // "3回目: 上：絆+5、体力+50、やる気+1、編成サポカ次ターン得意率30"
+                // "      下：絆+5、やる気+1、全ステ+8、スキルPt+10、編成サポカ次ターン得意率30"
+                // This implies a choice. Need to model this selection.
+                // For now, let's pick one path (e.g., upper choice).
+                newState = newState.addRelation(5, memberIndex = state.tuckerBlighIndex)
+                newState = newState.addStatus(Status(hp = 50, motivation = 1))
+                // TODO: "編成サポカ次ターン得意率30"
+                newState = newState.updateMujintoStatus { copy(tuckerSpecialtyBuffNextTurn = true, tuckerSpecialtyBuffNextTurnAmount = 30) }
+
+            }
+            // 4 -> { /* TODO: 4回目 */ }
+            5 -> {
+                // "5回目: 絆+5、体力+30、やる気+1、パワー+30、パスファインダーLv3、編成サポカ次ターン得意率120"
+                newState = newState.addRelation(5, memberIndex = state.tuckerBlighIndex)
+                newState = newState.addStatus(Status(hp = 30, motivation = 1, power = 30, skillHint = mapOf("パスファインダー" to 3)))
+                // TODO: "編成サポカ次ターン得意率120"
+                 newState = newState.updateMujintoStatus { copy(tuckerSpecialtyBuffNextTurn = true, tuckerSpecialtyBuffNextTurnAmount = 120) }
+            }
+        }
+        // TODO: "初回", "クラシック正月", "育成終了後" events for Tucker.
+        return newState
+    }
+
+    override fun updateScenarioTurn(state: SimulationState): SimulationState {
+        var newState = super.updateScenarioTurn(state)
+        val mujintoStatus = newState.mujintoStatus ?: return newState
+
+        // Apply Tucker Bligh's next turn specialty rate up if flagged
+        if (mujintoStatus.tuckerSpecialtyBuffNextTurn) {
+            val amount = mujintoStatus.tuckerSpecialtyBuffNextTurnAmount
+            // TODO: Iterate through all *other* support cards and apply this buff.
+            // This requires modifying MemberState or having a global effect list.
+            // For now, just log that it would happen.
+            // println("Applying Tucker Bligh's specialty rate buff ($amount%) to other support cards for turn ${newState.turn}")
+            newState = newState.updateMujintoStatus { copy(tuckerSpecialtyBuffNextTurn = false, tuckerSpecialtyBuffNextTurnAmount = 0) }
+        }
+
+        return newState
+    }
+
+    // Helper to get Tucker Bligh's index (placeholder)
+    private val SimulationState.tuckerBlighIndex: Int
+        get() = member.indexOfFirst { it.card.name == "タッカーブライン" } // This is a guess for card name
+
+}
+
+fun SimulationState.addRelation(amount: Int, memberIndex: Int): SimulationState {
+    if (memberIndex == -1 || memberIndex >= member.size) return this
+    return this.copy(
+        member = this.member.mapIndexed { index, m ->
+            if (index == memberIndex) m.addRelation(amount) else m
+        }
+    )
 }

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoStatus.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/MujintoStatus.kt
@@ -1,0 +1,74 @@
+package io.github.mee1080.umasim.scenario.mujinto
+
+import io.github.mee1080.umasim.scenario.Scenario
+import io.github.mee1080.umasim.simulation2.ScenarioMemberState
+import io.github.mee1080.umasim.simulation2.ScenarioStatus
+import io.github.mee1080.umasim.simulation2.SimulationState
+
+// Helper function to update MujintoStatus
+fun SimulationState.updateMujintoStatus(update: MujintoStatus.() -> MujintoStatus): SimulationState {
+    val mujintoStatus = this.mujintoStatus ?: return this
+    return copy(scenarioStatus = mujintoStatus.update())
+}
+
+// Enum for Facility Types
+enum class FacilityType {
+    SPEED,
+    STAMINA,
+    POWER,
+    GUTS,
+    WISDOM,
+    SPECIAL // For special effect facilities
+}
+
+// Data class for a single Facility
+data class Facility(
+    val type: FacilityType,
+    var level: Int = 0,
+    var constructionProgress: Int = 0 // Could represent accumulated Development Points for this facility
+) {
+    // According to memo: Lv1-3: 1 mass, Lv4: 2 mass, Lv5: 3 mass. Special is always 3 mass?
+    // This might be relevant for UI or complex construction logic, but for now, level is enough.
+}
+
+// Main Scenario Status for Mujinto
+data class MujintoStatus(
+    val facilities: Map<FacilityType, Facility> = FacilityType.entries.associateWith { Facility(it) },
+    var developmentPoints: Int = 0,
+    var islandTrainingTickets: Int = 0, // "特別な期間を除き1枚のみ所有可能" - max 1 unless special event
+    var evaluationMeetingCount: Int = 0, // To track how many evaluation meetings have occurred
+    val eventFlags: Set<String> = emptySet(), // For one-time events like ticket awards
+    val tuckerSpecialtyBuffNextTurn: Boolean = false, // Flag for Tucker's post-training buff
+    val tuckerSpecialtyBuffNextTurnAmount: Int = 0, // Amount for Tucker's outing buff
+    // TODO: Add other specific status fields based on mujinto_memo.md as details become clearer
+    // e.g., specific buffs from facilities, status of "建設計画" (construction plan order), active training buffs
+) : ScenarioStatus {
+    // Placeholder for facility effects
+    fun getFacilitySpeedBonus(): Int {
+        val speedFacility = facilities[FacilityType.SPEED] ?: return 0
+        // Example: "スピードLv1: 島トレ・島スピードにスピボ1", "島スピードのトレ効果5%"
+        // This needs more detailed logic based on how "島トレ効果" is applied.
+        // For now, a simple bonus.
+        return when (speedFacility.level) {
+            1 -> 5 // Placeholder value
+            2 -> 10 // Placeholder value
+            3 -> 15 // Placeholder value
+            4 -> 20 // Placeholder value
+            5 -> 25 // Placeholder value
+            else -> 0
+        }
+    }
+    // TODO: Add similar functions for other facility types and effects
+}
+
+// Scenario-specific state for support cards, especially for Tucker Bligh
+data class MujintoMemberState(
+    val exampleField: Int = 0 // Placeholder for Tucker Bligh specific mechanics
+    // TODO: Define fields relevant to Tucker Bligh's unique interactions if any,
+    // e.g., tracking her "得意率アップ" buff for other cards.
+) : ScenarioMemberState(Scenario.MUJINTO) {
+    override fun addRelation(relation: Int): ScenarioMemberState {
+        // TODO: Implement if Tucker Bligh or other cards have special relation gain mechanics
+        return this
+    }
+}

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/mujintoTrainingData.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/mujinto/mujintoTrainingData.kt
@@ -1,6 +1,48 @@
 package io.github.mee1080.umasim.scenario.mujinto
 
+import io.github.mee1080.umasim.data.Status
+import io.github.mee1080.umasim.data.StatusType
 import io.github.mee1080.umasim.data.TrainingBase
 
-// TODO: 無人島シナリオのトレーニングデータを定義
-val mujintoTrainingData: List<TrainingBase> = emptyList()
+// TODO: Replace with actual Mujinto scenario training data once available.
+// These are placeholder values.
+// The structure assumes 5 levels for each training type.
+// HP costs and specific stat gains need to be verified from mujinto_memo.md or game data.
+
+val mujintoTrainingData: List<TrainingBase> = listOf(
+    // Speed Training (Placeholder Values)
+    TrainingBase(StatusType.SPEED, 1, 500, Status(speed = 10, power = 2, skillPt = 5, hp = -20)),
+    TrainingBase(StatusType.SPEED, 2, 505, Status(speed = 11, power = 2, skillPt = 5, hp = -20)),
+    TrainingBase(StatusType.SPEED, 3, 510, Status(speed = 12, power = 3, skillPt = 6, hp = -21)),
+    TrainingBase(StatusType.SPEED, 4, 515, Status(speed = 13, power = 3, skillPt = 6, hp = -21)),
+    TrainingBase(StatusType.SPEED, 5, 520, Status(speed = 14, power = 4, skillPt = 7, hp = -22)),
+
+    // Stamina Training (Placeholder Values)
+    TrainingBase(StatusType.STAMINA, 1, 500, Status(stamina = 9, guts = 3, skillPt = 5, hp = -20)),
+    TrainingBase(StatusType.STAMINA, 2, 505, Status(stamina = 10, guts = 3, skillPt = 5, hp = -20)),
+    TrainingBase(StatusType.STAMINA, 3, 510, Status(stamina = 11, guts = 4, skillPt = 6, hp = -21)),
+    TrainingBase(StatusType.STAMINA, 4, 515, Status(stamina = 12, guts = 4, skillPt = 6, hp = -21)),
+    TrainingBase(StatusType.STAMINA, 5, 520, Status(stamina = 13, guts = 5, skillPt = 7, hp = -22)),
+
+    // Power Training (Placeholder Values)
+    TrainingBase(StatusType.POWER, 1, 500, Status(speed = 2, power = 9, stamina = 2, skillPt = 5, hp = -20)),
+    TrainingBase(StatusType.POWER, 2, 505, Status(speed = 2, power = 10, stamina = 2, skillPt = 5, hp = -20)),
+    TrainingBase(StatusType.POWER, 3, 510, Status(speed = 3, power = 11, stamina = 3, skillPt = 6, hp = -21)),
+    TrainingBase(StatusType.POWER, 4, 515, Status(speed = 3, power = 12, stamina = 3, skillPt = 6, hp = -21)),
+    TrainingBase(StatusType.POWER, 5, 520, Status(speed = 4, power = 13, stamina = 4, skillPt = 7, hp = -22)),
+
+    // Guts Training (Placeholder Values)
+    TrainingBase(StatusType.GUTS, 1, 500, Status(stamina = 3, power = 3, guts = 7, skillPt = 5, hp = -20)),
+    TrainingBase(StatusType.GUTS, 2, 505, Status(stamina = 3, power = 3, guts = 8, skillPt = 5, hp = -20)),
+    TrainingBase(StatusType.GUTS, 3, 510, Status(stamina = 4, power = 4, guts = 9, skillPt = 6, hp = -21)),
+    TrainingBase(StatusType.GUTS, 4, 515, Status(stamina = 4, power = 4, guts = 10, skillPt = 6, hp = -21)),
+    TrainingBase(StatusType.GUTS, 5, 520, Status(stamina = 5, power = 5, guts = 11, skillPt = 7, hp = -22)),
+
+    // Wisdom Training (Placeholder Values)
+    // Wisdom training usually recovers HP or has a lower HP cost.
+    TrainingBase(StatusType.WISDOM, 1, 300, Status(speed = 2, wisdom = 9, skillPt = 8, hp = 5)),
+    TrainingBase(StatusType.WISDOM, 2, 305, Status(speed = 2, wisdom = 10, skillPt = 8, hp = 5)),
+    TrainingBase(StatusType.WISDOM, 3, 310, Status(speed = 3, wisdom = 11, skillPt = 9, hp = 6)),
+    TrainingBase(StatusType.WISDOM, 4, 315, Status(speed = 3, wisdom = 12, skillPt = 9, hp = 6)),
+    TrainingBase(StatusType.WISDOM, 5, 320, Status(speed = 4, wisdom = 13, skillPt = 10, hp = 7))
+)


### PR DESCRIPTION
Adds the basic structure for the Mujinto scenario based on mujinto_memo.md.

Includes:
- Data structures (MujintoStatus, Facility, etc.)
- Placeholder training data (mujintoTrainingData)
- MujintoCalculator with placeholder logic for scenario mechanics
- MujintoScenarioEvents to handle scenario lifecycle, development points, evaluation meetings, and basic Tucker Bligh events.
- Initial integration of Tucker Bligh's mechanics (flags for specialty buff).
- Registration of the MUJINTO scenario in Scenario.kt.

Numerous TODOs mark areas requiring more specific data and logic from the memo or game data. This version serves as a foundational framework.