### PR TITLE
BCシナリオのトレーニング計算機能の追加

### DIFF
--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
@@ -312,6 +312,22 @@ fun TrainingInfo(model: ViewModel, state: State) {
         if (!state.scenario.guestMember) {
             H3 { Text("上振れ度: ${(state.upperRate * 10000.0).roundToInt() / 100.0}% (クライマックスでホイッスルを使って上昇量合計が今より低くなる確率)") }
         }
+        if (state.scenario == Scenario.BC) {
+            val bcStatus = state.bcStatusIfEnabled
+            if (bcStatus != null) {
+                NestedHideBlock("BCシナリオボーナス") {
+                    Div { Text("チームランク: ${io.github.mee1080.umasim.scenario.bc.rankToString.getOrElse(bcStatus.teamRank) { "" }}") }
+                    Div { Text("友情ボーナス: +${bcStatus.friendBonus}%") }
+                    Div { Text("トレーニング効果（チームメンバー）: +${bcStatus.trainingEffect(state.selectedTrainingTypeForScenario)}%") }
+                    if (bcStatus.dreamsTrainingActive) {
+                        Div { Text("サブ基礎能力上昇率: ${bcStatus.subParameterRate}%") }
+                        Div { Text("体力消費軽減: ${bcStatus.hpCostDown}%") }
+                        Div { Text("スキルPt上昇量アップ: ${bcStatus.skillPtEffect}%") }
+                        Div { Text("ヒント発生率アップ: ${bcStatus.teamRankEffect.hintFrequencyUp}%") }
+                    }
+                }
+            }
+        }
         if (state.trainingImpact.isNotEmpty()) {
             NestedHideBlock("サポカ影響度") {
                 Div {

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/BcTrainingSetting.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/BcTrainingSetting.kt
@@ -1,0 +1,85 @@
+package io.github.mee1080.umasim.web.page.top.setting
+
+import androidx.compose.runtime.Composable
+import io.github.mee1080.umasim.scenario.Scenario
+import io.github.mee1080.umasim.scenario.bc.rankToString
+import io.github.mee1080.umasim.web.components.atoms.MdCheckbox
+import io.github.mee1080.umasim.web.components.atoms.MdRadioGroup
+import io.github.mee1080.umasim.web.components.atoms.onChange
+import io.github.mee1080.umasim.web.components.parts.DivFlexCenter
+import io.github.mee1080.umasim.web.components.parts.NestedHideBlock
+import io.github.mee1080.umasim.web.components.parts.SliderEntry
+import io.github.mee1080.umasim.web.state.BCState
+import io.github.mee1080.umasim.web.state.WebConstants.trainingTypeList
+import io.github.mee1080.umasim.web.vm.ViewModel
+import org.jetbrains.compose.web.css.*
+import org.jetbrains.compose.web.dom.*
+
+@Composable
+fun BcTrainingSetting(model: ViewModel, state: BCState) {
+    NestedHideBlock(Scenario.BC.displayName) {
+        H4 { Text("チームパラメータ") }
+        SliderEntry("フィジカル：", state.physicalLevel, 1, 8) {
+            model.updateBC { copy(physicalLevel = it.toInt()) }
+        }
+        SliderEntry("テクニック：", state.techniqueLevel, 1, 8) {
+            model.updateBC { copy(techniqueLevel = it.toInt()) }
+        }
+        SliderEntry("メンタル：", state.mentalLevel, 1, 8) {
+            model.updateBC { copy(mentalLevel = it.toInt()) }
+        }
+
+        DivFlexCenter {
+            MdCheckbox("DREAMSトレーニング中", state.dreamsTrainingActive) {
+                onChange { model.updateBC { copy(dreamsTrainingActive = it) } }
+            }
+        }
+
+        H4 { Text("チームメンバー") }
+        state.teamMembers.forEachIndexed { index, member ->
+            Div({ style { marginTop(8.px); padding(8.px); border(1.px, LineStyle.Solid, Color.lightgray); borderRadius(4.px) } }) {
+                Div({ style { fontWeight("bold") } }) { Text(member.charaName) }
+                DivFlexCenter {
+                    SliderEntry("ランク", member.memberRank, 0, 16) { value ->
+                        model.updateBC {
+                            copy(teamMembers = teamMembers.toMutableList().also {
+                                it[index] = it[index].copy(memberRank = value.toInt())
+                            })
+                        }
+                    }
+                    Span({ style { marginLeft(8.px) } }) {
+                        Text("(${rankToString.getOrElse(member.memberRank) { "" }})")
+                    }
+                }
+
+                DivFlexCenter {
+                    MdCheckbox("ドリームゲージ最大", member.dreamGaugeMax) {
+                        onChange { value ->
+                            model.updateBC {
+                                copy(teamMembers = teamMembers.toMutableList().also {
+                                    it[index] = it[index].copy(dreamGaugeMax = value)
+                                })
+                            }
+                        }
+                    }
+                }
+
+                DivFlexCenter {
+                    Text("配置：")
+                    MdRadioGroup(
+                        trainingTypeList,
+                        member.position,
+                        onSelect = { value ->
+                            model.updateBC {
+                                copy(teamMembers = teamMembers.toMutableList().also {
+                                    it[index] = it[index].copy(position = value)
+                                })
+                            }
+                        },
+                        itemToLabel = { it.displayName }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/TrainingSetting.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/TrainingSetting.kt
@@ -73,5 +73,8 @@ fun TrainingSetting(model: ViewModel, state: State) {
         if (state.scenario == Scenario.MECHA) {
             MechaTrainingSetting(model, state.mechaState)
         }
+        if (state.scenario == Scenario.BC) {
+            BcTrainingSetting(model, state.bcState)
+        }
     }
 }

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/BCState.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/BCState.kt
@@ -1,0 +1,42 @@
+package io.github.mee1080.umasim.web.state
+
+import io.github.mee1080.umasim.data.StatusType
+import io.github.mee1080.umasim.scenario.bc.BCStatus
+import io.github.mee1080.umasim.scenario.bc.BCTeamMember
+import io.github.mee1080.umasim.scenario.bc.BCTeamParameter
+
+data class BCState(
+    val teamMembers: List<BCMemberState> = listOf(
+        BCMemberState("メンバー1"),
+        BCMemberState("メンバー2"),
+        BCMemberState("メンバー3")
+    ),
+    val physicalLevel: Int = 1,
+    val techniqueLevel: Int = 1,
+    val mentalLevel: Int = 1,
+    val dreamsTrainingActive: Boolean = false,
+) {
+    fun toBCStatus() = BCStatus(
+        teamMember = teamMembers.map { it.toBCTeamMember() },
+        teamParameter = mapOf(
+            BCTeamParameter.Physical to physicalLevel,
+            BCTeamParameter.Technique to techniqueLevel,
+            BCTeamParameter.Mental to mentalLevel,
+        ),
+        dreamsTrainingActive = dreamsTrainingActive
+    )
+}
+
+data class BCMemberState(
+    val charaName: String,
+    val memberRank: Int = 0,
+    val dreamGaugeMax: Boolean = false,
+    val position: StatusType = StatusType.SPEED,
+) {
+    fun toBCTeamMember() = BCTeamMember(
+        charaName = charaName,
+        dreamGauge = if (dreamGaugeMax) 3 else 0,
+        memberRank = memberRank,
+        position = position
+    )
+}

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
@@ -94,6 +94,7 @@ data class State(
     val cookState: CookState = CookState(),
     val mechaState: MechaState = MechaState(),
     val mujintoState: MujintoState = MujintoState(),
+    val bcState: BCState = BCState(),
 ) {
 
     val supportFilterApplied get() = supportFilter == appliedSupportFilter
@@ -154,6 +155,7 @@ data class State(
             ?: cookStatusIfEnabled
             ?: mechaStatusIfEnabled
             ?: mujintoStatusIfEnabled
+            ?: bcStatusIfEnabled
 
     val trainingLiveStateIfEnabled get() = if (scenario == Scenario.GRAND_LIVE) trainingLiveState else null
 
@@ -171,6 +173,8 @@ data class State(
         ) else null
 
     val mujintoStatusIfEnabled get() = if (scenario == Scenario.MUJINTO) mujintoState.toMujintoStatus() else null
+
+    val bcStatusIfEnabled get() = if (scenario == Scenario.BC) bcState.toBCStatus() else null
 
     val specialityRateUp
         get() = when (scenario) {

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/BCViewModel.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/BCViewModel.kt
@@ -1,0 +1,9 @@
+package io.github.mee1080.umasim.web.vm
+
+import io.github.mee1080.umasim.web.state.BCState
+
+class BCViewModel(private val root: ViewModel) {
+    fun update(update: BCState.() -> BCState) {
+        root.update { copy(bcState = bcState.update()) }
+    }
+}

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
@@ -58,6 +58,8 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
 
     val graphViewModel = GraphViewModel(this)
 
+    val bcViewModel = BCViewModel(this)
+
     fun navigate(page: Page) {
         state = state.copy(page = page)
     }
@@ -846,5 +848,9 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
 
     fun updateMujinto(update: MujintoState.() -> MujintoState) {
         update { copy(mujintoState = mujintoState.update()) }
+    }
+
+    fun updateBC(update: BCState.() -> BCState) {
+        update { copy(bcState = bcState.update()) }
     }
 }


### PR DESCRIPTION
webモジュールに、BCシナリオ（Beyond Dreams 共に前へ、共に光を）のトレーニングでのステータス上昇量計算機能を追加しました。

主な変更内容：
- webモジュールのStateにBCシナリオ用の状態を追加し、coreモジュールのBCCalculatorを呼び出すためのマッピングロジックを実装。
- BCシナリオ専用のViewModelを追加し、画面からの状態更新を可能にしました。
- UI側では、チームパラメータ（フィジカル、テクニック、メンタル）、DREAMSトレーニングの有無、およびチームメンバー3名の詳細（ランク、ドリームゲージ、配置場所）を設定できるパネルを追加しました。
- 計算結果の表示部分に、BCシナリオ固有のボーナス（チームランク、友人、トレ効、DREAMSボーナスなど）の内訳を表示するように更新しました。

ビルドコマンド `./gradlew kotlinUpgradeYarnLock :web:jsBrowserDistribution` にて正常にビルドできることを確認済みです。
また、Playwrightを使用した検証により、UI要素の表示および状態更新が正しく機能していることを確認しました。

---
*PR created automatically by Jules for task [7763539905075278509](https://jules.google.com/task/7763539905075278509) started by @mee1080*