### PR TITLE
BCシナリオのトレーニング設定の修正

### DIFF
--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/BcTrainingSetting.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/BcTrainingSetting.kt
@@ -4,13 +4,11 @@ import androidx.compose.runtime.Composable
 import io.github.mee1080.umasim.scenario.Scenario
 import io.github.mee1080.umasim.scenario.bc.rankToString
 import io.github.mee1080.umasim.web.components.atoms.MdCheckbox
-import io.github.mee1080.umasim.web.components.atoms.MdRadioGroup
 import io.github.mee1080.umasim.web.components.atoms.onChange
 import io.github.mee1080.umasim.web.components.parts.DivFlexCenter
 import io.github.mee1080.umasim.web.components.parts.NestedHideBlock
 import io.github.mee1080.umasim.web.components.parts.SliderEntry
 import io.github.mee1080.umasim.web.state.BCState
-import io.github.mee1080.umasim.web.state.WebConstants.trainingTypeList
 import io.github.mee1080.umasim.web.vm.ViewModel
 import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.*
@@ -27,12 +25,6 @@ fun BcTrainingSetting(model: ViewModel, state: BCState) {
         }
         SliderEntry("メンタル：", state.mentalLevel, 1, 8) {
             model.updateBC { copy(mentalLevel = it.toInt()) }
-        }
-
-        DivFlexCenter {
-            MdCheckbox("DREAMSトレーニング中", state.dreamsTrainingActive) {
-                onChange { model.updateBC { copy(dreamsTrainingActive = it) } }
-            }
         }
 
         H4 { Text("チームメンバー") }
@@ -53,6 +45,15 @@ fun BcTrainingSetting(model: ViewModel, state: BCState) {
                 }
 
                 DivFlexCenter {
+                    MdCheckbox("配置あり", member.placed) {
+                        onChange { value ->
+                            model.updateBC {
+                                copy(teamMembers = teamMembers.toMutableList().also {
+                                    it[index] = it[index].copy(placed = value)
+                                })
+                            }
+                        }
+                    }
                     MdCheckbox("ドリームゲージ最大", member.dreamGaugeMax) {
                         onChange { value ->
                             model.updateBC {
@@ -63,22 +64,12 @@ fun BcTrainingSetting(model: ViewModel, state: BCState) {
                         }
                     }
                 }
+            }
+        }
 
-                DivFlexCenter {
-                    Text("配置：")
-                    MdRadioGroup(
-                        trainingTypeList,
-                        member.position,
-                        onSelect = { value ->
-                            model.updateBC {
-                                copy(teamMembers = teamMembers.toMutableList().also {
-                                    it[index] = it[index].copy(position = value)
-                                })
-                            }
-                        },
-                        itemToLabel = { it.displayName }
-                    )
-                }
+        DivFlexCenter {
+            MdCheckbox("DREAMSトレーニング中", state.dreamsTrainingActive) {
+                onChange { model.updateBC { copy(dreamsTrainingActive = it) } }
             }
         }
     }

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/BCState.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/BCState.kt
@@ -16,8 +16,8 @@ data class BCState(
     val mentalLevel: Int = 1,
     val dreamsTrainingActive: Boolean = false,
 ) {
-    fun toBCStatus() = BCStatus(
-        teamMember = teamMembers.map { it.toBCTeamMember() },
+    fun toBCStatus(selectedTrainingType: StatusType) = BCStatus(
+        teamMember = teamMembers.map { it.toBCTeamMember(selectedTrainingType) },
         teamParameter = mapOf(
             BCTeamParameter.Physical to physicalLevel,
             BCTeamParameter.Technique to techniqueLevel,
@@ -31,12 +31,12 @@ data class BCMemberState(
     val charaName: String,
     val memberRank: Int = 0,
     val dreamGaugeMax: Boolean = false,
-    val position: StatusType = StatusType.SPEED,
+    val placed: Boolean = false,
 ) {
-    fun toBCTeamMember() = BCTeamMember(
+    fun toBCTeamMember(currentPosition: StatusType) = BCTeamMember(
         charaName = charaName,
         dreamGauge = if (dreamGaugeMax) 3 else 0,
         memberRank = memberRank,
-        position = position
+        position = if (placed) currentPosition else StatusType.NONE
     )
 }

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
@@ -174,7 +174,7 @@ data class State(
 
     val mujintoStatusIfEnabled get() = if (scenario == Scenario.MUJINTO) mujintoState.toMujintoStatus() else null
 
-    val bcStatusIfEnabled get() = if (scenario == Scenario.BC) bcState.toBCStatus() else null
+    val bcStatusIfEnabled get() = if (scenario == Scenario.BC) bcState.toBCStatus(selectedTrainingType) else null
 
     val specialityRateUp
         get() = when (scenario) {


### PR DESCRIPTION
BCシナリオのトレーニング設定の利便性向上のため、UIレイアウトと配置ロジックを修正しました。

1. BcTrainingSetting.kt:
   - "DREAMSトレーニング中"チェックボックスを設定項目の一番下に移動しました。
   - メンバーごとの配置先選択（ラジオボタン）を「配置あり」チェックボックスに変更しました。
   - 「配置あり」チェックボックスを「ドリームゲージ最大」の左側に配置しました。

2. BCState.kt:
   - BCMemberStateのposition(StatusType)をplaced(Boolean)に変更しました。
   - toBCStatusおよびtoBCTeamMemberが現在の選択トレーニング種別を受け取り、配置ありのメンバーをその種別に割り当てるように修正しました。

3. State.kt:
   - bcStatusIfEnabledからtoBCStatusを呼び出す際に、現在選択されているトレーニング種別を渡すように修正しました。


---
*PR created automatically by Jules for task [8283885747407066793](https://jules.google.com/task/8283885747407066793) started by @mee1080*