### PR TITLE
Add Full Spurt feature

### DIFF
--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
@@ -16,8 +16,10 @@ import io.github.mee1080.umasim.race.data2.ApproximateMultiCondition
 import io.github.mee1080.umasim.race.data2.approximateConditions
 import io.github.mee1080.umasim.store.AppState
 import io.github.mee1080.umasim.store.framework.OperationDispatcher
+import io.github.mee1080.umasim.store.operation.setFullSpurtCoef
 import io.github.mee1080.umasim.store.operation.setPositionKeepMode
 import io.github.mee1080.umasim.store.operation.setPositionKeepRate
+import io.github.mee1080.utility.roundToString
 import io.github.mee1080.utility.toPercentString
 
 @Composable
@@ -32,6 +34,19 @@ fun ApproximateSetting(state: AppState, dispatch: OperationDispatcher<AppState>)
             Text("近似条件", style = MaterialTheme.typography.headlineSmall)
             Text("以下の項目は、シミュレーションが難しいため、近似処理を行っています")
             Text("（いずれ変更できるようにしたい）", style = MaterialTheme.typography.bodySmall)
+        }
+
+        Column {
+            val fullSpurtCoef by derivedStateOf { state.setting.fullSpurtCoef }
+            Text("全開スパート", style = MaterialTheme.typography.titleLarge)
+            Text("全開スパート係数: ${fullSpurtCoef.roundToString(3)}")
+            Slider(
+                value = fullSpurtCoef.toFloat(),
+                onValueChange = { dispatch(setFullSpurtCoef(it.toDouble())) },
+                valueRange = 0f..0.1f,
+                steps = 99,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
 
         Column {

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
@@ -286,6 +286,7 @@ private fun toGraphData(setting: RaceSetting, frameList: List<RaceFrame>?): Grap
                 add(frameList, index, raceFrame, "持久力温存") { it.staminaKeep }
 //                add(index, raceFrame, last, "リード確保") { it.secureLead }
                 add(frameList, index, raceFrame, "スタミナ勝負") { it.staminaLimitBreak }
+                add(frameList, index, raceFrame, "全開スパート") { it.fullSpurt }
 //                if (raceFrame.positionKeepState != PositionKeepState.NONE && raceFrame.positionKeepState != last.positionKeepState) {
 //                    add(index / 15f to raceFrame.positionKeepState.label)
 //                }

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
@@ -43,6 +43,10 @@ fun setPositionKeepRate(value: Int) = DirectOperation<AppState> { state ->
     state.updateSetting { it.copy(positionKeepRate = value) }
 }
 
+fun setFullSpurtCoef(value: Double) = DirectOperation<AppState> { state ->
+    state.updateSetting { it.copy(fullSpurtCoef = value) }
+}
+
 fun setThreadCount(value: Int) = DirectOperation<AppState> { state ->
     state.copy(threadCount = value).also { it.saveSetting() }
 }

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceCalculator.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceCalculator.kt
@@ -192,6 +192,7 @@ private fun RaceState.updateFrame(): Boolean {
         staminaKeep = simulation.staminaKeep,
         secureLead = simulation.secureLead,
         staminaLimitBreak = simulation.staminaLimitBreak,
+        fullSpurt = simulation.fullSpurt,
         paceMakerFrame = paceMaker?.simulation?.frames?.lastOrNull(),
     )
     // 1秒おき判定
@@ -312,6 +313,12 @@ private fun RaceState.updateFrame(): Boolean {
         if (simulation.currentSpeed >= setting.maxSpurtSpeed) {
             simulation.staminaLimitBreak = true
         }
+    }
+
+    // 全開スパート
+    // TODO: 判定方法の修正が必要
+    if (setting.umaStatus.speed > 2000 && currentPhase == 3) {
+        simulation.fullSpurt = true
     }
 
     move(secondPerFrame)

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
@@ -238,6 +238,10 @@ class RaceState(
                 result += setting.staminaLimitBreakSpeed
             }
 
+            if (simulation.fullSpurt) {
+                result += sqrt(setting.umaStatus.speed.toDouble()) * setting.fullSpurtCoef
+            }
+
             return result
         }
 
@@ -257,8 +261,10 @@ class RaceState(
             if (simulation.isStartDash) {
                 acceleration += 24.0
             }
-            simulation.operatingSkills.forEach {
-                acceleration += it.acceleration
+            if (!simulation.fullSpurt) {
+                simulation.operatingSkills.forEach {
+                    acceleration += it.acceleration
+                }
             }
             if (simulation.competeFight) {
                 acceleration += setting.competeFightAcceleration
@@ -393,6 +399,7 @@ interface IRaceSetting {
     val coolDownBaseFrames: Double
     val skillActivateRate: Double
     val timeCoef: Double
+    val fullSpurtCoef: Double
     val oonige: Boolean
     val phase0Half: Double
     val phase1Start: Double
@@ -420,6 +427,7 @@ data class RaceSetting(
     override val positionKeepMode: PositionKeepMode = PositionKeepMode.APPROXIMATE,
     override val positionKeepRate: Int = 100,
     override val virtualLeader: UmaStatus = UmaStatus(),
+    override val fullSpurtCoef: Double = 0.0,
 ) : IRaceSetting {
     override val fixRandom get() = skillActivateAdjustment == SkillActivateAdjustment.ALL
     override val runningStyle by lazy { if (oonige) Style.OONIGE else umaStatus.style }
@@ -754,6 +762,7 @@ class RaceSimulationState(
     var secureLead: Boolean = false,
     var secureLeadNextFrame: Int = 0,
     var staminaLimitBreak: Boolean = false,
+    var fullSpurt: Boolean = false,
 
     val invokedSkills: List<InvokedSkill> = emptyList(),
     val coolDownMap: MutableMap<String, Int> = mutableMapOf(),
@@ -850,6 +859,7 @@ data class RaceFrame(
     val staminaKeep: Boolean = false,
     val secureLead: Boolean = false,
     val staminaLimitBreak: Boolean = false,
+    val fullSpurt: Boolean = false,
     val paceMakerFrame: RaceFrame? = null,
 )
 


### PR DESCRIPTION
This change adds the "Full Spurt" (全開スパート) feature to the race emulator.
It includes:
- Simulation logic update: A new "Full Spurt" flag is triggered when speed > 2000 and phase is 3.
- Performance effects: Increases target speed based on a configurable coefficient and excludes skill-based acceleration during full spurt.
- UI improvements: A new configuration section in "Approximate Conditions" with a slider for the full spurt coefficient.
- Visualization: The "Full Spurt" interval is now shown on the race results graph.

---
*PR created automatically by Jules for task [17750116976074339358](https://jules.google.com/task/17750116976074339358) started by @mee1080*