### PR TITLE
Update Secure Lead speed boost for Nige strategy

### DIFF
--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
@@ -12,12 +12,14 @@ import io.github.mee1080.umasim.compose.common.atoms.SelectBox
 import io.github.mee1080.umasim.race.data.PositionKeepMode
 import io.github.mee1080.umasim.race.data.defaultFullSpurtAccelCoef
 import io.github.mee1080.umasim.race.data.defaultFullSpurtCoef
+import io.github.mee1080.umasim.race.data.defaultSecureLeadNigeBoost
 import io.github.mee1080.umasim.race.data2.ApproximateMultiCondition
 import io.github.mee1080.umasim.race.data2.approximateConditions
 import io.github.mee1080.umasim.store.AppState
 import io.github.mee1080.umasim.store.framework.OperationDispatcher
 import io.github.mee1080.umasim.store.operation.setFullSpurtAccelCoef
 import io.github.mee1080.umasim.store.operation.setFullSpurtCoef
+import io.github.mee1080.umasim.store.operation.setSecureLeadNigeBoost
 import io.github.mee1080.umasim.store.operation.setPositionKeepMode
 import io.github.mee1080.umasim.store.operation.setPositionKeepRate
 import io.github.mee1080.utility.roundToString
@@ -29,6 +31,7 @@ fun ApproximateSetting(state: AppState, dispatch: OperationDispatcher<AppState>)
     val positionKeepRate by derivedStateOf { state.setting.positionKeepRate }
     val fullSpurtCoef by derivedStateOf { state.setting.fullSpurtCoef }
     val fullSpurtAccelCoef by derivedStateOf { state.setting.fullSpurtAccelCoef }
+    val secureLeadNigeBoost by derivedStateOf { state.setting.secureLeadNigeBoost }
     HorizontalDivider()
 
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -186,7 +189,20 @@ fun ApproximateSetting(state: AppState, dispatch: OperationDispatcher<AppState>)
         Column {
             Text("リード確保", style = MaterialTheme.typography.titleLarge)
             Text("追込以外で、${systemSetting.secureLeadRate.toPercentString()}の確率で発動します")
-            Text("自身の作戦が逃げ、かつ相手の作戦が逃げ以外の場合、速度上昇量が1.2倍になります")
+            Text("自身の作戦が逃げ、かつ相手の作戦が逃げ以外の場合、速度上昇量が設定した係数で倍増します")
+            Text("速度倍率: ${secureLeadNigeBoost.roundToString(2)}")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Slider(
+                    value = secureLeadNigeBoost.toFloat(),
+                    onValueChange = { dispatch(setSecureLeadNigeBoost(it.toDouble())) },
+                    valueRange = 1f..2f,
+                    steps = 99,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(
+                    onClick = { dispatch(setSecureLeadNigeBoost(defaultSecureLeadNigeBoost)) },
+                ) { Text("リセット") }
+            }
         }
 
         Column {

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
@@ -186,6 +186,7 @@ fun ApproximateSetting(state: AppState, dispatch: OperationDispatcher<AppState>)
         Column {
             Text("リード確保", style = MaterialTheme.typography.titleLarge)
             Text("追込以外で、${systemSetting.secureLeadRate.toPercentString()}の確率で発動します")
+            Text("自身の作戦が逃げ、かつ相手の作戦が逃げ以外の場合、速度上昇量が1.2倍になります")
         }
 
         Column {

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
@@ -51,6 +51,10 @@ fun setFullSpurtAccelCoef(value: Double) = DirectOperation<AppState> { state ->
     state.updateSetting { it.copy(fullSpurtAccelCoef = value) }
 }
 
+fun setSecureLeadNigeBoost(value: Double) = DirectOperation<AppState> { state ->
+    state.updateSetting { it.copy(secureLeadNigeBoost = value) }
+}
+
 fun setThreadCount(value: Int) = DirectOperation<AppState> { state ->
     state.copy(threadCount = value).also { it.saveSetting() }
 }

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
@@ -419,6 +419,7 @@ interface IRaceSetting {
     val timeCoef: Double
     val fullSpurtCoef: Double
     val fullSpurtAccelCoef: Double
+    val secureLeadNigeBoost: Double
     val oonige: Boolean
     val phase0Half: Double
     val phase1Start: Double
@@ -448,6 +449,7 @@ data class RaceSetting(
     override val virtualLeader: UmaStatus = UmaStatus(),
     override val fullSpurtCoef: Double = defaultFullSpurtCoef,
     override val fullSpurtAccelCoef: Double = defaultFullSpurtAccelCoef,
+    override val secureLeadNigeBoost: Double = defaultSecureLeadNigeBoost,
 ) : IRaceSetting {
     override val fixRandom get() = skillActivateAdjustment == SkillActivateAdjustment.ALL
     override val runningStyle by lazy { if (oonige) Style.OONIGE else umaStatus.style }
@@ -701,7 +703,7 @@ class RaceSettingWithPassive(
         } else {
             virtualLeader.style
         }
-        val multiplier = if (runningStyle == Style.NIGE && virtualLeaderRunningStyle != Style.NIGE) 1.2 else 1.0
+        val multiplier = if (runningStyle == Style.NIGE && virtualLeaderRunningStyle != Style.NIGE) secureLeadNigeBoost else 1.0
         (modifiedGuts / 2000.0).pow(0.5) * 0.3 * secureLeadSpeedCoef[runningStyle]!! * multiplier
     }
 

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
@@ -696,7 +696,13 @@ class RaceSettingWithPassive(
     }
 
     val secureLeadSpeed by lazy {
-        (modifiedGuts / 2000.0).pow(0.5) * 0.3 * secureLeadSpeedCoef[runningStyle]!!
+        val virtualLeaderRunningStyle = if (virtualLeader.style == Style.NIGE && virtualLeader.hasSkills.any { s -> s.invokes.any { it.oonige } }) {
+            Style.OONIGE
+        } else {
+            virtualLeader.style
+        }
+        val multiplier = if (runningStyle == Style.NIGE && virtualLeaderRunningStyle != Style.NIGE) 1.2 else 1.0
+        (modifiedGuts / 2000.0).pow(0.5) * 0.3 * secureLeadSpeedCoef[runningStyle]!! * multiplier
     }
 
     val secureLeadStamina by lazy {

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/data/constants.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/data/constants.kt
@@ -100,6 +100,7 @@ const val laneChangeAccelerationPerFrame = laneChangeAcceleration / framePerSeco
 
 const val defaultFullSpurtCoef = 0.05
 const val defaultFullSpurtAccelCoef = 0.02
+const val defaultSecureLeadNigeBoost = 1.2
 
 /**
  * やる気->ステータス補正倍率


### PR DESCRIPTION
This change updates the "Secure Lead" (リード確保) mechanic in the race simulation. When a character's strategy is "NIGE" (逃げ) and the virtual pacemaker is not "NIGE" (specifically excluding "OONIGE" (大逃げ) from both), the speed boost from Lead Secure is increased by 1.2x. 

The UI description in the "Approximate Setting" page has also been updated to reflect this change.

---
*PR created automatically by Jules for task [14537286274240884215](https://jules.google.com/task/14537286274240884215) started by @mee1080*