### PR TITLE
Make positioning adjustment activation rate configurable

### DIFF
--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
@@ -9,10 +9,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.mee1080.umasim.compose.common.atoms.SelectBox
-import io.github.mee1080.umasim.race.data.PositionKeepMode
-import io.github.mee1080.umasim.race.data.defaultFullSpurtAccelCoef
-import io.github.mee1080.umasim.race.data.defaultFullSpurtCoef
-import io.github.mee1080.umasim.race.data.defaultSecureLeadNigeBoost
+import io.github.mee1080.umasim.race.data.*
 import io.github.mee1080.umasim.race.data2.ApproximateMultiCondition
 import io.github.mee1080.umasim.race.data2.approximateConditions
 import io.github.mee1080.umasim.store.AppState
@@ -180,6 +177,18 @@ fun ApproximateSetting(state: AppState, dispatch: OperationDispatcher<AppState>)
         Column {
             Text("位置取り調整", style = MaterialTheme.typography.titleLarge)
             Text("持久力温存でなければ、${systemSetting.positionCompetitionRate.toPercentString()}の確率で発動します")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Slider(
+                    value = (systemSetting.positionCompetitionRate * 100).toFloat(),
+                    onValueChange = { dispatch(setPositionCompetitionRate(it.toDouble() / 100.0)) },
+                    valueRange = 0f..100f,
+                    steps = 99,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(
+                    onClick = { dispatch(setPositionCompetitionRate(defaultPositionCompetitionRate)) },
+                ) { Text("リセット") }
+            }
         }
 
         Column {

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
@@ -62,3 +62,7 @@ fun setThreadCount(value: Int) = DirectOperation<AppState> { state ->
 fun setSkillLaneChangeRate(value: Double) = DirectOperation<AppState> { state ->
     state.updateSystemSetting { it.copy(skillLaneChangeRate = value) }
 }
+
+fun setPositionCompetitionRate(value: Double) = DirectOperation<AppState> { state ->
+    state.updateSystemSetting { it.copy(positionCompetitionRate = value) }
+}

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
@@ -948,6 +948,7 @@ class InvokedSkill(
 @Serializable
 data class SystemSetting(
     val skillLaneChangeRate: Double = 0.4,
+    val positionCompetitionRate: Double = defaultPositionCompetitionRate,
 ) {
     @Transient
     val positionKeepSectionSen: List<Boolean> = List(10) { it == 0 }
@@ -963,9 +964,6 @@ data class SystemSetting(
 
     @Transient
     val competeFightRate: Double = 0.4
-
-    @Transient
-    val positionCompetitionRate: Double = 0.8
 
     @Transient
     val staminaKeepRate: Double = 0.9

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/data/constants.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/data/constants.kt
@@ -102,6 +102,7 @@ const val laneChangeAccelerationPerFrame = laneChangeAcceleration / framePerSeco
 const val defaultFullSpurtCoef = 0.05
 const val defaultFullSpurtAccelCoef = 0.02
 const val defaultSecureLeadNigeBoost = 1.2
+const val defaultPositionCompetitionRate = 0.8
 
 /**
  * やる気->ステータス補正倍率


### PR DESCRIPTION
The "positioning adjustment" (位置取り調整) activation rate, which was previously fixed at 0.8 (80%), has been made configurable.

Key changes:
1.  **Model/Data**: Added `defaultPositionCompetitionRate` to `constants.kt` and moved `positionCompetitionRate` from a `@Transient` property to a serializable constructor parameter in `SystemSetting`. This ensures the setting is saved and restored automatically.
2.  **State/Operation**: Implemented `setPositionCompetitionRate(value: Double)` in `SettingOperation.kt` to handle updates through the application's dispatcher pattern.
3.  **UI**: Modified `ApproximateSetting.kt` in the `compose` module to include a `Slider` and a "Reset" `Button`. The slider allows users to set the rate from 0% to 100% in 1% increments, and the reset button restores the default 80% value.

These changes allow for more flexible race simulations by letting users adjust the likelihood of positioning adjustments during the race.

---
*PR created automatically by Jules for task [11101715668072382149](https://jules.google.com/task/11101715668072382149) started by @mee1080*