### PR TITLE
グラフのツールチップに発動位置の割合を表示

### DIFF
--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/GraphOutput.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/GraphOutput.kt
@@ -143,19 +143,13 @@ private fun GraphArea(graphData: GraphData) {
                     graphData.skillData.forEachIndexed { index, skill ->
                         val top = 1f - skillMargin * index
                         XYAnnotation(Point(skill.start, top), AnchorPoint.TopLeft) {
-                            if (skill.description.isEmpty()) {
+                            WithTooltip(
+                                tooltip = {
+                                    Text(skill.description)
+                                }
+                            ) {
                                 TooltipSurface(containerColor = Color(0, 0, 0, 128)) {
                                     Text(skill.name)
-                                }
-                            } else {
-                                WithTooltip(
-                                    tooltip = {
-                                        Text(skill.description)
-                                    }
-                                ) {
-                                    TooltipSurface(containerColor = Color(0, 0, 0, 128)) {
-                                        Text(skill.name)
-                                    }
                                 }
                             }
                         }

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/AppState.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/AppState.kt
@@ -7,10 +7,7 @@ import io.github.mee1080.umasim.race.data2.SkillData
 import io.github.mee1080.umasim.race.data2.skillData2
 import io.github.mee1080.umasim.store.framework.State
 import io.github.mee1080.umasim.store.operation.updateSetting
-import io.github.mee1080.utility.decodeFromStringOrNull
-import io.github.mee1080.utility.encodeToString
-import io.github.mee1080.utility.persistentSettings
-import io.github.mee1080.utility.roundToString
+import io.github.mee1080.utility.*
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
@@ -194,6 +191,8 @@ data class GraphSkill(
     val end: Float?,
     val name: String,
     val effect: TriggeredSkill?,
+    val startRate: Double = 0.0,
+    val endRate: Double? = null,
 ) {
     val description = buildString {
         if (effect != null) {
@@ -227,6 +226,12 @@ data class GraphSkill(
                     appendLine("持続時間：${operating.duration.roundToString(2)}")
                 }
             }
+        }
+        val startPercent = startRate.toPercentString(1)
+        if (endRate != null) {
+            appendLine("${startPercent}〜${endRate.toPercentString(1)}")
+        } else {
+            appendLine(startPercent)
         }
     }.trim()
 }

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
@@ -271,23 +271,32 @@ private fun toGraphData(setting: RaceSetting, frameList: List<RaceFrame>?): Grap
         skillData = buildList {
             frameList.forEachIndexed { index, raceFrame ->
                 raceFrame.triggeredSkills.forEach { skill ->
-                    val end = searchFrame(frameList, index + 1) { frame ->
+                    val endIndex = searchFrame(frameList, index + 1) { frame ->
                         frame.endedSkills.any { it.data.skill.id == skill.invoke.skill.id }
                     }
-                    add(GraphSkill(index / 15f, end?.div(15f), skill.invoke.skill.name, skill))
+                    add(
+                        GraphSkill(
+                            start = index / 15f,
+                            end = endIndex?.div(15f),
+                            name = skill.invoke.skill.name,
+                            effect = skill,
+                            startRate = raceFrame.startPosition / setting.courseLength,
+                            endRate = endIndex?.let { frameList[it].startPosition / setting.courseLength },
+                        )
+                    )
                 }
-                add(frameList, index, raceFrame, "掛かり") { it.temptation }
+                add(setting, frameList, index, raceFrame, "掛かり") { it.temptation }
 //                add(index, raceFrame, last, "スパート開始") { it.spurting }
 //                add(index, raceFrame, last, "ペースダウンモード") { it.paceDownMode }
-                add(frameList, index, raceFrame, "下り坂モード") { it.downSlopeMode }
+                add(setting, frameList, index, raceFrame, "下り坂モード") { it.downSlopeMode }
 //                add(index, raceFrame, last, "位置取り争い") { it.leadCompetition }
-                add(frameList, index, raceFrame, "追い比べ") { it.competeFight }
+                add(setting, frameList, index, raceFrame, "追い比べ") { it.competeFight }
 //                add(index, raceFrame, last, "脚色十分") { it.conservePower }
 //                add(index, raceFrame, last, "位置取り調整") { it.positionCompetition }
-                add(frameList, index, raceFrame, "持久力温存") { it.staminaKeep }
+                add(setting, frameList, index, raceFrame, "持久力温存") { it.staminaKeep }
 //                add(index, raceFrame, last, "リード確保") { it.secureLead }
-                add(frameList, index, raceFrame, "スタミナ勝負") { it.staminaLimitBreak }
-                add(frameList, index, raceFrame, "全開スパート") { it.fullSpurt }
+                add(setting, frameList, index, raceFrame, "スタミナ勝負") { it.staminaLimitBreak }
+                add(setting, frameList, index, raceFrame, "全開スパート") { it.fullSpurt }
 //                if (raceFrame.positionKeepState != PositionKeepState.NONE && raceFrame.positionKeepState != last.positionKeepState) {
 //                    add(index / 15f to raceFrame.positionKeepState.label)
 //                }
@@ -302,6 +311,7 @@ private fun toGraphData(setting: RaceSetting, frameList: List<RaceFrame>?): Grap
 }
 
 private fun MutableList<GraphSkill>.add(
+    setting: RaceSetting,
     frameList: List<RaceFrame>,
     frame: Int,
     raceFrame: RaceFrame,
@@ -310,7 +320,16 @@ private fun MutableList<GraphSkill>.add(
 ) {
     if (check(raceFrame) && (frame == 0 || !check(frameList[frame - 1]))) {
         val end = searchFrame(frameList, frame + 1) { !check(it) } ?: frameList.lastIndex
-        add(GraphSkill(frame / 15f, end / 15f, label, null))
+        add(
+            GraphSkill(
+                start = frame / 15f,
+                end = end / 15f,
+                name = label,
+                effect = null,
+                startRate = raceFrame.startPosition / setting.courseLength,
+                endRate = frameList[end].startPosition / setting.courseLength,
+            )
+        )
     }
 }
 


### PR DESCRIPTION
composeモジュールのグラフのツールチップに、発動位置のコース長さに対する割合を表示するようにしました。開始位置のみの場合は「xx.x%」、開始位置と終了位置がある場合は「xx.x%〜yy.y%」と表記されます。また、説明文がない項目についてもツールチップが表示されるように変更しました。

---
*PR created automatically by Jules for task [12665746247851158861](https://jules.google.com/task/12665746247851158861) started by @mee1080*