### PR TITLE
Add graph visibility settings to the compose module

### DIFF
--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/GraphOutput.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/GraphOutput.kt
@@ -1,9 +1,7 @@
 package io.github.mee1080.umasim.compose.pages.race
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
@@ -28,13 +26,15 @@ import io.github.mee1080.umasim.compose.common.atoms.TooltipSurface
 import io.github.mee1080.umasim.compose.common.parts.WithTooltip
 import io.github.mee1080.umasim.store.AppState
 import io.github.mee1080.umasim.store.GraphData
+import io.github.mee1080.umasim.store.framework.OperationDispatcher
+import io.github.mee1080.umasim.store.operation.setGraphDisplaySetting
 import kotlin.math.max
 import kotlin.math.min
 
 @Composable
-fun GraphOutput(state: AppState) {
+fun GraphOutput(state: AppState, dispatch: OperationDispatcher<AppState>) {
     val graphData = state.graphData ?: return
-    GraphArea(graphData)
+    GraphArea(state, graphData, dispatch)
 }
 
 private val defaultLegends = listOf(
@@ -47,9 +47,9 @@ private val virtualLegends = defaultLegends + listOf(
     "先頭との差" to Color(0, 255, 255),
 )
 
-@OptIn(ExperimentalKoalaPlotApi::class)
+@OptIn(ExperimentalKoalaPlotApi::class, ExperimentalLayoutApi::class)
 @Composable
-private fun GraphArea(graphData: GraphData) {
+private fun GraphArea(state: AppState, graphData: GraphData, dispatch: OperationDispatcher<AppState>) {
     val frameList = graphData.frameList
     Column {
         Text("直近レース詳細", style = MaterialTheme.typography.headlineSmall)
@@ -161,6 +161,51 @@ private fun GraphArea(graphData: GraphData) {
                         }
                     }
                 }
+            }
+        }
+        val setting = state.graphDisplaySetting
+        FlowRow(
+            modifier = Modifier.padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            LabeledCheckbox(setting.skill, { dispatch(setGraphDisplaySetting(setting.copy(skill = it))) }) {
+                Text("スキル")
+            }
+            LabeledCheckbox(setting.temptation, { dispatch(setGraphDisplaySetting(setting.copy(temptation = it))) }) {
+                Text("掛かり")
+            }
+            LabeledCheckbox(setting.spurting, { dispatch(setGraphDisplaySetting(setting.copy(spurting = it))) }) {
+                Text("スパート開始")
+            }
+            LabeledCheckbox(setting.paceDownMode, { dispatch(setGraphDisplaySetting(setting.copy(paceDownMode = it))) }) {
+                Text("ペースダウンモード")
+            }
+            LabeledCheckbox(setting.downSlopeMode, { dispatch(setGraphDisplaySetting(setting.copy(downSlopeMode = it))) }) {
+                Text("下り坂モード")
+            }
+            LabeledCheckbox(setting.leadCompetition, { dispatch(setGraphDisplaySetting(setting.copy(leadCompetition = it))) }) {
+                Text("位置取り争い")
+            }
+            LabeledCheckbox(setting.competeFight, { dispatch(setGraphDisplaySetting(setting.copy(competeFight = it))) }) {
+                Text("追い比べ")
+            }
+            LabeledCheckbox(setting.conservePower, { dispatch(setGraphDisplaySetting(setting.copy(conservePower = it))) }) {
+                Text("脚色十分")
+            }
+            LabeledCheckbox(setting.positionCompetition, { dispatch(setGraphDisplaySetting(setting.copy(positionCompetition = it))) }) {
+                Text("位置取り調整")
+            }
+            LabeledCheckbox(setting.staminaKeep, { dispatch(setGraphDisplaySetting(setting.copy(staminaKeep = it))) }) {
+                Text("持久力温存")
+            }
+            LabeledCheckbox(setting.secureLead, { dispatch(setGraphDisplaySetting(setting.copy(secureLead = it))) }) {
+                Text("リード確保")
+            }
+            LabeledCheckbox(setting.staminaLimitBreak, { dispatch(setGraphDisplaySetting(setting.copy(staminaLimitBreak = it))) }) {
+                Text("スタミナ勝負")
+            }
+            LabeledCheckbox(setting.fullSpurt, { dispatch(setGraphDisplaySetting(setting.copy(fullSpurt = it))) }) {
+                Text("全開スパート")
             }
         }
     }

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/RacePage.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/RacePage.kt
@@ -26,7 +26,7 @@ fun RacePage(state: AppState, dispatch: OperationDispatcher<AppState>) {
         ModeInput(state, dispatch)
         ActionInput(state, dispatch)
         SummaryOutput(state)
-        GraphOutput(state)
+        GraphOutput(state, dispatch)
         LastSimulationDetailOutput(state)
         ContributionOutput(state)
         ApproximateSetting(state, dispatch)

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/AppState.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/AppState.kt
@@ -45,6 +45,24 @@ enum class SimulationMode(val label: String) {
 
 @Stable
 @Serializable
+data class GraphDisplaySetting(
+    val skill: Boolean = true,
+    val temptation: Boolean = true,
+    val spurting: Boolean = true,
+    val paceDownMode: Boolean = true,
+    val downSlopeMode: Boolean = true,
+    val leadCompetition: Boolean = true,
+    val competeFight: Boolean = true,
+    val conservePower: Boolean = true,
+    val positionCompetition: Boolean = true,
+    val staminaKeep: Boolean = true,
+    val secureLead: Boolean = true,
+    val staminaLimitBreak: Boolean = true,
+    val fullSpurt: Boolean = true,
+)
+
+@Stable
+@Serializable
 data class AppState(
     val setting: RaceSetting = RaceSetting(),
     val systemSetting: SystemSetting = SystemSetting(),
@@ -55,6 +73,7 @@ data class AppState(
     val simulationCount: Int = 100,
     val simulationMode: SimulationMode = SimulationMode.NORMAL,
     val contributionTargets: Set<String> = emptySet(),
+    val graphDisplaySetting: GraphDisplaySetting = GraphDisplaySetting(),
     val threadCount: Int = defaultThreadCount,
     @Transient
     val simulationProgress: Int = 0,

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
@@ -11,6 +11,7 @@ import io.github.mee1080.umasim.race.data2.SkillData
 import io.github.mee1080.umasim.race.data2.skillData2
 import io.github.mee1080.umasim.store.*
 import io.github.mee1080.umasim.store.framework.ActionContext
+import io.github.mee1080.umasim.store.framework.DirectOperation
 import io.github.mee1080.umasim.store.framework.AsyncOperation
 import io.github.mee1080.umasim.store.framework.OnRunning
 import io.github.mee1080.utility.averageOf
@@ -72,7 +73,7 @@ private suspend fun ActionContext<AppState>.runSimulationNormal(state: AppState,
             lastRaceState = result.second
         }
     }
-    val graphData = toGraphData(state.setting, lastRaceState?.simulation?.frames)
+    val graphData = toGraphData(state.setting, lastRaceState?.simulation?.frames, state.graphDisplaySetting)
     val spurtResults = results.filter { it.maxSpurt }
     val notSpurtResult = results.filter { !it.maxSpurt }
     val summary = SimulationSummary(
@@ -237,7 +238,11 @@ private const val areaHeight = 0.1f
 
 private fun adjustRange(value: Double, min: Float, max: Float) = (value.toFloat() - min) / (max - min)
 
-private fun toGraphData(setting: RaceSetting, frameList: List<RaceFrame>?): GraphData? {
+internal fun toGraphData(
+    setting: RaceSetting,
+    frameList: List<RaceFrame>?,
+    displaySetting: GraphDisplaySetting
+): GraphData? {
     if (frameList.isNullOrEmpty()) return null
     val staminaMax = frameList[0].sp.toFloat()
     val trackDetail = setting.trackDetail
@@ -270,36 +275,35 @@ private fun toGraphData(setting: RaceSetting, frameList: List<RaceFrame>?): Grap
         downSlopeData = toGraphData(trackDetail.slopes.filter { it.slope < 0f }.map { it.start to it.end }, frameList),
         skillData = buildList {
             frameList.forEachIndexed { index, raceFrame ->
-                raceFrame.triggeredSkills.forEach { skill ->
-                    val endIndex = searchFrame(frameList, index + 1) { frame ->
-                        frame.endedSkills.any { it.data.skill.id == skill.invoke.skill.id }
-                    }
-                    add(
-                        GraphSkill(
-                            start = index / 15f,
-                            end = endIndex?.div(15f),
-                            name = skill.invoke.skill.name,
-                            effect = skill,
-                            startRate = raceFrame.startPosition / setting.courseLength,
-                            endRate = endIndex?.let { frameList[it].startPosition / setting.courseLength },
+                if (displaySetting.skill) {
+                    raceFrame.triggeredSkills.forEach { skill ->
+                        val endIndex = searchFrame(frameList, index + 1) { frame ->
+                            frame.endedSkills.any { it.data.skill.id == skill.invoke.skill.id }
+                        }
+                        add(
+                            GraphSkill(
+                                start = index / 15f,
+                                end = endIndex?.div(15f),
+                                name = skill.invoke.skill.name,
+                                effect = skill,
+                                startRate = raceFrame.startPosition / setting.courseLength,
+                                endRate = endIndex?.let { frameList[it].startPosition / setting.courseLength },
+                            )
                         )
-                    )
+                    }
                 }
-                add(setting, frameList, index, raceFrame, "掛かり") { it.temptation }
-//                add(index, raceFrame, last, "スパート開始") { it.spurting }
-//                add(index, raceFrame, last, "ペースダウンモード") { it.paceDownMode }
-                add(setting, frameList, index, raceFrame, "下り坂モード") { it.downSlopeMode }
-//                add(index, raceFrame, last, "位置取り争い") { it.leadCompetition }
-                add(setting, frameList, index, raceFrame, "追い比べ") { it.competeFight }
-//                add(index, raceFrame, last, "脚色十分") { it.conservePower }
-//                add(index, raceFrame, last, "位置取り調整") { it.positionCompetition }
-                add(setting, frameList, index, raceFrame, "持久力温存") { it.staminaKeep }
-//                add(index, raceFrame, last, "リード確保") { it.secureLead }
-                add(setting, frameList, index, raceFrame, "スタミナ勝負") { it.staminaLimitBreak }
-                add(setting, frameList, index, raceFrame, "全開スパート") { it.fullSpurt }
-//                if (raceFrame.positionKeepState != PositionKeepState.NONE && raceFrame.positionKeepState != last.positionKeepState) {
-//                    add(index / 15f to raceFrame.positionKeepState.label)
-//                }
+                if (displaySetting.temptation) add(setting, frameList, index, raceFrame, "掛かり") { it.temptation }
+                if (displaySetting.spurting) add(setting, frameList, index, raceFrame, "スパート開始") { it.spurting }
+                if (displaySetting.paceDownMode) add(setting, frameList, index, raceFrame, "ペースダウンモード") { it.positionKeepState == PositionKeepState.PACE_DOWN }
+                if (displaySetting.downSlopeMode) add(setting, frameList, index, raceFrame, "下り坂モード") { it.downSlopeMode }
+                if (displaySetting.leadCompetition) add(setting, frameList, index, raceFrame, "位置取り争い") { it.leadCompetition }
+                if (displaySetting.competeFight) add(setting, frameList, index, raceFrame, "追い比べ") { it.competeFight }
+                if (displaySetting.conservePower) add(setting, frameList, index, raceFrame, "脚色十分") { it.conservePower }
+                if (displaySetting.positionCompetition) add(setting, frameList, index, raceFrame, "位置取り調整") { it.positionCompetition }
+                if (displaySetting.staminaKeep) add(setting, frameList, index, raceFrame, "持久力温存") { it.staminaKeep }
+                if (displaySetting.secureLead) add(setting, frameList, index, raceFrame, "リード確保") { it.secureLead }
+                if (displaySetting.staminaLimitBreak) add(setting, frameList, index, raceFrame, "スタミナ勝負") { it.staminaLimitBreak }
+                if (displaySetting.fullSpurt) add(setting, frameList, index, raceFrame, "全開スパート") { it.fullSpurt }
             }
         }.sortedBy { it.start },
         paceMakerData = frameList.mapIndexedNotNull { index, raceFrame ->
@@ -376,6 +380,13 @@ private fun toGraphData(
 fun cancelSimulation() = AsyncOperation<AppState>({
     send { it.clearSimulationResult() }
 }, simulationCancelPolicy)
+
+fun setGraphDisplaySetting(value: GraphDisplaySetting) = DirectOperation<AppState> { state ->
+    state.copy(
+        graphDisplaySetting = value,
+        graphData = toGraphData(state.setting, state.graphData?.frameList, value)
+    ).also { it.saveSetting() }
+}
 
 private sealed interface ContributionTarget {
     fun applySetting(setting: RaceSetting): RaceSetting


### PR DESCRIPTION
This change adds a set of checkboxes below the race graph in the `compose` module, allowing users to toggle the visibility of various simulation data points (Skills, Temptation, Spurt Start, Pace Down Mode, etc.). 

Key changes:
1.  **State Management**: Added `GraphDisplaySetting` data class to `AppState` to store boolean flags for each toggleable item. These settings are persisted.
2.  **Logic**: Modified `toGraphData` in `RaceOperation.kt` to respect these settings when building the `GraphData`. It now supports items that were previously commented out, such as "Pace Down Mode" and "Lead Competition".
3.  **Real-time Updates**: Implemented a `setGraphDisplaySetting` operation that regenerates the graph data from existing simulation frames when a setting is changed, providing immediate visual feedback.
4.  **UI**: Added a `FlowRow` of `LabeledCheckbox` components in `GraphOutput.kt` to provide a user-friendly interface for these settings.

The "Skills" toggle controls all individual skills simultaneously as requested. The "Pace Down Mode" visibility is triggered when the character's position keep state is `PACE_DOWN`.

---
*PR created automatically by Jules for task [11287608993890276666](https://jules.google.com/task/11287608993890276666) started by @mee1080*