### PR TITLE
Add activation rate settings for compete fight and secure lead

### DIFF
--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/ApproximateSetting.kt
@@ -10,14 +10,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.mee1080.umasim.compose.common.atoms.SelectBox
 import io.github.mee1080.umasim.race.data.PositionKeepMode
+import io.github.mee1080.umasim.race.data.defaultCompeteFightRate
 import io.github.mee1080.umasim.race.data.defaultPositionCompetitionRate
+import io.github.mee1080.umasim.race.data.defaultSecureLeadRate
 import io.github.mee1080.umasim.race.data2.ApproximateMultiCondition
 import io.github.mee1080.umasim.race.data2.approximateConditions
 import io.github.mee1080.umasim.store.AppState
 import io.github.mee1080.umasim.store.framework.OperationDispatcher
-import io.github.mee1080.umasim.store.operation.setPositionCompetitionRate
-import io.github.mee1080.umasim.store.operation.setPositionKeepMode
-import io.github.mee1080.umasim.store.operation.setPositionKeepRate
+import io.github.mee1080.umasim.store.operation.*
 import io.github.mee1080.utility.toPercentString
 
 @Composable
@@ -131,6 +131,18 @@ fun ApproximateSetting(state: AppState, dispatch: OperationDispatcher<AppState>)
         Column {
             Text("追い比べ", style = MaterialTheme.typography.titleLarge)
             Text("最終直線で1秒毎に、${systemSetting.competeFightRate.toPercentString()}の確率で発動します")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Slider(
+                    value = (systemSetting.competeFightRate * 100).toFloat(),
+                    onValueChange = { dispatch(setCompeteFightRate(it.toDouble() / 100.0)) },
+                    valueRange = 0f..100f,
+                    steps = 99,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(
+                    onClick = { dispatch(setCompeteFightRate(defaultCompeteFightRate)) },
+                ) { Text("リセット") }
+            }
         }
 
         Column {
@@ -167,6 +179,18 @@ fun ApproximateSetting(state: AppState, dispatch: OperationDispatcher<AppState>)
             Text("リード確保", style = MaterialTheme.typography.titleLarge)
             Text("追込以外で、${systemSetting.secureLeadRate.toPercentString()}の確率で発動します")
             Text("自身の作戦が逃げ、ポジションキープモードが仮想ペースメーカー、かつ相手の作戦が自身と異なる場合、速度上昇量に倍率がかかります")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Slider(
+                    value = (systemSetting.secureLeadRate * 100).toFloat(),
+                    onValueChange = { dispatch(setSecureLeadRate(it.toDouble() / 100.0)) },
+                    valueRange = 0f..100f,
+                    steps = 99,
+                    modifier = Modifier.weight(1f),
+                )
+                Button(
+                    onClick = { dispatch(setSecureLeadRate(defaultSecureLeadRate)) },
+                ) { Text("リセット") }
+            }
         }
 
         Column {

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
@@ -54,3 +54,11 @@ fun setSkillLaneChangeRate(value: Double) = DirectOperation<AppState> { state ->
 fun setPositionCompetitionRate(value: Double) = DirectOperation<AppState> { state ->
     state.updateSystemSetting { it.copy(positionCompetitionRate = value) }
 }
+
+fun setCompeteFightRate(value: Double) = DirectOperation<AppState> { state ->
+    state.updateSystemSetting { it.copy(competeFightRate = value) }
+}
+
+fun setSecureLeadRate(value: Double) = DirectOperation<AppState> { state ->
+    state.updateSystemSetting { it.copy(secureLeadRate = value) }
+}

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
@@ -949,6 +949,8 @@ class InvokedSkill(
 data class SystemSetting(
     val skillLaneChangeRate: Double = 0.4,
     val positionCompetitionRate: Double = defaultPositionCompetitionRate,
+    val competeFightRate: Double = defaultCompeteFightRate,
+    val secureLeadRate: Double = defaultSecureLeadRate,
 ) {
     @Transient
     val positionKeepSectionSen: List<Boolean> = List(10) { it == 1 }
@@ -963,13 +965,7 @@ data class SystemSetting(
     val leadCompetitionPosition: Int = 200
 
     @Transient
-    val competeFightRate: Double = 0.4
-
-    @Transient
     val staminaKeepRate: Double = 0.9
-
-    @Transient
-    val secureLeadRate: Double = 0.3
 }
 
 class TriggeredSkill(

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/data/constants.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/data/constants.kt
@@ -99,6 +99,8 @@ const val laneChangeAcceleration = 0.02 * 1.5
 const val laneChangeAccelerationPerFrame = laneChangeAcceleration / framePerSecond
 
 const val defaultPositionCompetitionRate = 0.8
+const val defaultCompeteFightRate = 0.4
+const val defaultSecureLeadRate = 0.3
 
 /**
  * やる気->ステータス補正倍率


### PR DESCRIPTION
This PR adds the ability to configure the activation rates for "Compete Fight" (追い比べ) and "Secure Lead" (リード確保) in the race simulation settings, following the existing pattern for "Position Competition" (位置取り調整). 

Changes:
- In the `race` module, default constants were defined and `SystemSetting` was modified to include these rates as persistent settings instead of hardcoded transient values.
- In the `compose` module, new dispatcher operations were added to update these values.
- The "Approximate Setting" (近似条件) UI was updated with sliders and reset buttons for both new settings.

---
*PR created automatically by Jules for task [347927628320167624](https://jules.google.com/task/347927628320167624) started by @mee1080*