### PR TITLE
Add debuff calculation and UI components

### DIFF
--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/DebuffInput.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/DebuffInput.kt
@@ -1,0 +1,47 @@
+package io.github.mee1080.umasim.compose.pages.race
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import io.github.mee1080.umasim.compose.common.parts.HideBlock
+import io.github.mee1080.umasim.compose.common.parts.NumberInput
+import io.github.mee1080.umasim.race.calc2.DebuffType
+import io.github.mee1080.umasim.store.AppState
+import io.github.mee1080.umasim.store.framework.OperationDispatcher
+import io.github.mee1080.umasim.store.operation.setDebuffCount
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun DebuffInput(state: AppState, dispatch: OperationDispatcher<AppState>) {
+    val debuffSetting = state.setting.debuffSetting
+    HideBlock(
+        header = { Text("デバフ") },
+        initialOpen = false,
+        headerClosed = {
+            val summary = debuffSetting.counts.filterValues { it > 0 }
+                .map { "${it.key.label}x${it.value}" }
+                .joinToString(", ")
+            Text("デバフ：$summary")
+        }
+    ) {
+        FlowRow(
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            DebuffType.entries.forEach { type ->
+                val count = debuffSetting.counts[type] ?: 0
+                NumberInput(
+                    label = { Text(type.label) },
+                    value = count,
+                    onValueChange = { dispatch(setDebuffCount(type, it)) },
+                    min = 0,
+                    max = 18,
+                )
+            }
+        }
+    }
+}

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/RacePage.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/compose/pages/race/RacePage.kt
@@ -21,6 +21,7 @@ fun RacePage(state: AppState, dispatch: OperationDispatcher<AppState>) {
         CharaInput(false, state, dispatch)
         CourseInput(state, dispatch)
         SkillInput(false, state, dispatch)
+        DebuffInput(state, dispatch)
         SettingInput(state, dispatch)
         HorizontalDivider()
         ModeInput(state, dispatch)

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
@@ -304,6 +304,17 @@ internal fun toGraphData(
                 if (displaySetting.secureLead) add(setting, frameList, index, raceFrame, "リード確保") { it.secureLead }
                 if (displaySetting.staminaLimitBreak) add(setting, frameList, index, raceFrame, "スタミナ勝負") { it.staminaLimitBreak }
                 if (displaySetting.fullSpurt) add(setting, frameList, index, raceFrame, "全開スパート") { it.fullSpurt }
+                raceFrame.triggeredDebuffs.forEach { debuff ->
+                    add(
+                        GraphSkill(
+                            start = index / 15f,
+                            end = null,
+                            name = "デバフ：${debuff.label}",
+                            effect = null,
+                            startRate = raceFrame.startPosition / setting.courseLength,
+                        )
+                    )
+                }
             }
         }.sortedBy { it.start },
         paceMakerData = frameList.mapIndexedNotNull { index, raceFrame ->

--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/SettingOperation.kt
@@ -62,3 +62,15 @@ fun setCompeteFightRate(value: Double) = DirectOperation<AppState> { state ->
 fun setSecureLeadRate(value: Double) = DirectOperation<AppState> { state ->
     state.updateSystemSetting { it.copy(secureLeadRate = value) }
 }
+
+fun setDebuffCount(type: io.github.mee1080.umasim.race.calc2.DebuffType, value: Int) = DirectOperation<AppState> { state ->
+    state.updateSetting { setting ->
+        setting.copy(
+            debuffSetting = setting.debuffSetting.copy(
+                counts = setting.debuffSetting.counts.toMutableMap().apply {
+                    if (value == 0) remove(type) else put(type, value)
+                }
+            )
+        )
+    }
+}

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceCalculator.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceCalculator.kt
@@ -88,6 +88,23 @@ class RaceCalculator(
 
         simulation.forceInSpeed = Random.nextDouble(0.1) * forceInFixed[umaStatus.style]!!
 
+        if (virtualLeader == null) {
+            debuffSetting.counts.forEach { (type, count) ->
+                val (start, end) = if (type.phase == 2) {
+                    // 終盤デバフはフェーズ2と3の両方を対象にする
+                    val p2 = getPhaseStartEnd(2)
+                    val p3 = getPhaseStartEnd(3)
+                    p2.first to p3.second
+                } else {
+                    getPhaseStartEnd(type.phase)
+                }
+                repeat(count) {
+                    val position = Random.nextDouble(start, end)
+                    simulation.debuffTriggers[position] = type
+                }
+            }
+        }
+
         return state
     }
 
@@ -251,6 +268,15 @@ private fun RaceState.updateFrame(): Boolean {
         simulation.positionKeepState = PositionKeepState.NONE
     }
 
+    // デバフ判定
+    val triggeredDebuffs = mutableListOf<DebuffType>()
+    val debuffs = simulation.debuffTriggers.filterKeys { it in simulation.startPosition..simulation.position }
+    debuffs.forEach { (pos, type) ->
+        simulation.sp -= setting.spMax * type.rate
+        triggeredDebuffs += type
+        simulation.debuffTriggers.remove(pos)
+    }
+
     // 位置取り争い
     if (simulation.leadCompetitionStart == null && setting.basicRunningStyle == Style.NIGE && simulation.position >= system.leadCompetitionPosition) {
         simulation.leadCompetitionStart = simulation.frameElapsed
@@ -333,7 +359,8 @@ private fun RaceState.updateFrame(): Boolean {
         movement = simulation.position - simulation.startPosition,
         consume = simulation.sp - startSp,
         targetSpeed = targetSpeed + fullSpurtTargetSpeed,
-        acceleration = acceleration + fullSpurtAcceleration
+        acceleration = acceleration + fullSpurtAcceleration,
+        triggeredDebuffs = triggeredDebuffs,
     )
     simulation.frameElapsed++
 

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
@@ -33,6 +33,21 @@ import kotlin.math.*
 const val NOT_SELECTED = "(未選択)"
 
 @Serializable
+enum class DebuffType(val label: String, val phase: Int, val rate: Double) {
+    EARLY_WHITE("序盤白（-1%）", 0, 0.01),
+    EARLY_GOLD("序盤金（-3%）", 0, 0.03),
+    MIDDLE_WHITE("中盤白（-1%）", 1, 0.01),
+    MIDDLE_GOLD("中盤金（-3%）", 1, 0.03),
+    LATE_WHITE("終盤白（-1%）", 2, 0.01),
+    LATE_GOLD("終盤金（-3%）", 2, 0.03),
+}
+
+@Serializable
+data class DebuffSetting(
+    val counts: Map<DebuffType, Int> = emptyMap()
+)
+
+@Serializable
 data class UmaStatus(
     val charaName: String = NOT_SELECTED,
     val speed: Int = 1800,
@@ -445,6 +460,8 @@ data class RaceSetting(
     override val positionKeepMode: PositionKeepMode = PositionKeepMode.APPROXIMATE,
     override val positionKeepRate: Int = 100,
     override val virtualLeader: UmaStatus = UmaStatus(),
+
+    val debuffSetting: DebuffSetting = DebuffSetting(),
 ) : IRaceSetting {
     override val fixRandom get() = skillActivateAdjustment == SkillActivateAdjustment.ALL
     override val runningStyle by lazy { if (oonige) Style.OONIGE else umaStatus.style }
@@ -814,6 +831,8 @@ class RaceSimulationState(
     var staminaKeepStart: Double = 0.0,
     var staminaKeepDistance: Double = 0.0,
 
+    val debuffTriggers: MutableMap<Double, DebuffType> = mutableMapOf(),
+
     var positionKeepState: PositionKeepState = PositionKeepState.NONE,
     var positionKeepNextFrame: Int = framePerSecond * 2,
     var positionKeepExitPosition: Double = 0.0,
@@ -902,6 +921,7 @@ data class RaceFrame(
     val secureLead: Boolean = false,
     val staminaLimitBreak: Boolean = false,
     val fullSpurt: Boolean = false,
+    val triggeredDebuffs: List<DebuffType> = emptyList(),
     val paceMakerFrame: RaceFrame? = null,
 )
 


### PR DESCRIPTION
This change introduces a debuff system to the race simulator. Users can now specify the number of debuffs for 'Early', 'Middle', and 'Late' phases (White -1%, Gold -3%). These debuffs are randomly triggered during the simulation within their respective phases, reducing the character's stamina. The activation points are visualized on the race graph. Debuffs are applied only to the main character to facilitate strategy analysis.

---
*PR created automatically by Jules for task [3349673969841939238](https://jules.google.com/task/3349673969841939238) started by @mee1080*