### PR TITLE
Wasm環境でのシミュレーション停止問題の修正とUIレスポンスの改善

### DIFF
--- a/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
+++ b/compose/src/commonMain/kotlin/io/github/mee1080/umasim/store/operation/RaceOperation.kt
@@ -50,30 +50,38 @@ private suspend fun ActionContext<AppState>.runSimulationNormal(state: AppState,
         it.name to mutableListOf<SimulationSkillInfo>()
     }
     val skillDataMap = state.hasSkills(false).associateBy { it.name }
-    var lastRaceState: RaceState? = null
+    var firstRaceState: RaceState? = null
     val scope = CoroutineScope(currentCoroutineContext() + asyncDispatcher.limitedParallelism(state.threadCount))
     var count = 0
-    List(simulationCount) {
-        scope.async {
-            if (count++ % progressReportInterval == 0) {
-                send { it.copy(simulationProgress = count + 1) }
+    val chunkSize = max(state.threadCount * 10, progressReportInterval)
+    for (chunk in (0 until simulationCount).chunked(chunkSize)) {
+        chunk.map { i ->
+            scope.async {
+                val result = RaceCalculator(state.systemSetting).simulate(state.setting)
+                val skillMap = createSkillMap(result.second)
+                if (i == 0) {
+                    result to skillMap
+                } else {
+                    (result.first to null) to skillMap
+                }
+            }
+        }.forEach { deferred ->
+            val (result, skillMap) = deferred.await()
+            results += result.first
+            skillMap.forEach {
+                skillSummaries[it.key]?.add(it.value)
+            }
+            if (firstRaceState == null) {
+                firstRaceState = result.second
+            }
+            count++
+            if (count % progressReportInterval == 0) {
+                send { it.copy(simulationProgress = count) }
                 delay(progressReportDelay)
             }
-            val result = RaceCalculator(state.systemSetting).simulate(state.setting)
-            val skillMap = createSkillMap(result.second)
-            result to skillMap
-        }
-    }.forEach { deferred ->
-        val (result, skillMap) = deferred.await()
-        results += result.first
-        skillMap.forEach {
-            skillSummaries[it.key]?.add(it.value)
-        }
-        if (lastRaceState == null) {
-            lastRaceState = result.second
         }
     }
-    val graphData = toGraphData(state.setting, lastRaceState?.simulation?.frames, state.graphDisplaySetting)
+    val graphData = toGraphData(state.setting, firstRaceState?.simulation?.frames, state.graphDisplaySetting)
     val spurtResults = results.filter { it.maxSpurt }
     val notSpurtResult = results.filter { !it.maxSpurt }
     val summary = SimulationSummary(
@@ -88,7 +96,7 @@ private suspend fun ActionContext<AppState>.runSimulationNormal(state: AppState,
         it.copy(
             simulationProgress = 0,
             simulationSummary = summary,
-            lastSimulationSettingWithPassive = lastRaceState?.setting,
+            lastSimulationSettingWithPassive = firstRaceState?.setting,
             graphData = graphData,
         )
     }
@@ -671,14 +679,22 @@ private class CalculateState(
 
     suspend fun calculateTimes(setting: RaceSetting): List<Double> {
         val scope = CoroutineScope(currentCoroutineContext() + asyncDispatcher.limitedParallelism(state.threadCount))
-        return List(state.simulationCount) {
-            scope.async {
-                if (progress++ % progressReportInterval == 0) {
+        val results = mutableListOf<Double>()
+        val chunkSize = max(state.threadCount * 10, progressReportInterval)
+        for (chunk in (0 until state.simulationCount).chunked(chunkSize)) {
+            chunk.map {
+                scope.async {
+                    RaceCalculator(state.systemSetting).simulate(setting).first.raceTime
+                }
+            }.forEach { deferred ->
+                results += deferred.await()
+                progress++
+                if (progress % (progressReportInterval * setCount) == 0) {
                     context.send { it.copy(simulationProgress = progress / setCount) }
                     delay(progressReportDelay)
                 }
-                RaceCalculator(state.systemSetting).simulate(setting).first.raceTime
             }
-        }.awaitAll().sorted()
+        }
+        return results.sorted()
     }
 }

--- a/compose/src/wasmJsMain/kotlin/io/github/mee1080/umasim/compose/common/lib/platform.wasmJs.kt
+++ b/compose/src/wasmJsMain/kotlin/io/github/mee1080/umasim/compose/common/lib/platform.wasmJs.kt
@@ -20,7 +20,7 @@ actual val defaultFontResource = Res.font.LINESeedJP_OTF_Rg
 
 actual val defaultThreadCount = 1
 
-actual val progressReportInterval = 50
+actual val progressReportInterval = 5
 
 actual val progressReportDelay = 10L
 


### PR DESCRIPTION
wasmターゲットにおいて、大量のシミュレーション（1000回程度）を実行すると画面更新が止まる問題を修正しました。
主な変更点は以下の通りです：
1. シミュレーションをチャンク分割して実行することで、一時に大量のコルーチンが起動されるのを防ぎ、メモリ使用量のピークを抑えました。
2. グラフ表示に必要なRaceState（フレームデータを含む）の保持を最初の1回分のみに限定し、メモリ消費を大幅に削減しました。
3. wasm環境におけるprogressReportIntervalを50から5に短縮し、UIがより頻繁に更新されるようにすることで、長時間ブロックされるのを防ぎました。

---
*PR created automatically by Jules for task [15672025532216552977](https://jules.google.com/task/15672025532216552977) started by @mee1080*