### PR TITLE
グラフページのモバイル用ヘッダーレイアウト修正

### DIFF
--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/graph/GraphPage.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/graph/GraphPage.kt
@@ -69,25 +69,59 @@ private fun MainArea(
 ) {
     var divider by remember { mutableStateOf<Double?>(0.0) }
     Div({ classes(S.wrapper) }) {
-        Div({ classes(S.header) }) {
-            MdOutlinedSelect(
-                selection = state.targetCandidates,
-                selectedItem = state.target,
-                onSelect = { viewModel.setGraphTarget(it) },
-                itemToValue = { it.path },
-                itemToDisplayText = { it.displayName },
-            )
-            MdFilledButton("フィルタ") {
-                onClick { viewModel.openGraphFilterDialog() }
+        Div({
+            classes(S.header)
+            if (slim) {
+                style {
+                    flexDirection(FlexDirection.Column)
+                    alignItems(AlignItems.FlexStart)
+                }
             }
-            MdRadioGroup(
-                selection = GraphSortOrder.entries,
-                selectedItem = state.sortOrder,
-                onSelect = { viewModel.setGraphSortOrder(it) },
-                itemToLabel = { it.displayName },
-            )
-            MdCheckbox("上下分割", divider != null) {
-                onChange { divider = if (it) 0.0 else null }
+        }) {
+            if (slim) {
+                Div({ classes(S.headerRow) }) {
+                    MdOutlinedSelect(
+                        selection = state.targetCandidates,
+                        selectedItem = state.target,
+                        onSelect = { viewModel.setGraphTarget(it) },
+                        itemToValue = { it.path },
+                        itemToDisplayText = { it.displayName },
+                    )
+                    MdFilledButton("フィルタ") {
+                        onClick { viewModel.openGraphFilterDialog() }
+                    }
+                }
+                Div({ classes(S.headerRow) }) {
+                    MdRadioGroup(
+                        selection = GraphSortOrder.entries,
+                        selectedItem = state.sortOrder,
+                        onSelect = { viewModel.setGraphSortOrder(it) },
+                        itemToLabel = { it.displayName },
+                    )
+                    MdCheckbox("上下分割", divider != null) {
+                        onChange { divider = if (it) 0.0 else null }
+                    }
+                }
+            } else {
+                MdOutlinedSelect(
+                    selection = state.targetCandidates,
+                    selectedItem = state.target,
+                    onSelect = { viewModel.setGraphTarget(it) },
+                    itemToValue = { it.path },
+                    itemToDisplayText = { it.displayName },
+                )
+                MdFilledButton("フィルタ") {
+                    onClick { viewModel.openGraphFilterDialog() }
+                }
+                MdRadioGroup(
+                    selection = GraphSortOrder.entries,
+                    selectedItem = state.sortOrder,
+                    onSelect = { viewModel.setGraphSortOrder(it) },
+                    itemToLabel = { it.displayName },
+                )
+                MdCheckbox("上下分割", divider != null) {
+                    onChange { divider = if (it) 0.0 else null }
+                }
             }
         }
         val dividerValue = divider
@@ -130,6 +164,16 @@ private val S = object : ScopedStyleSheet() {
 
     val header by style {
         display(DisplayStyle.Flex)
+        alignItems(AlignItems.Center)
+        gap(4.px)
+        padding(4.px)
+    }
+
+    val headerRow by style {
+        display(DisplayStyle.Flex)
+        alignItems(AlignItems.Center)
+        flexWrap(FlexWrap.Wrap)
+        gap(4.px)
     }
 
     val dividedGraph by style {


### PR DESCRIPTION
GraphPageのヘッダーがモバイル（横幅不足）で崩れる問題を修正しました。
slimモード（800px未満）の際に、ヘッダー要素を2段に分割し、左寄せにするように変更しました。
- 1段目：セレクトボックス、フィルタボタン
- 2段目：ラジオボタン（ソート順）、チェックボックス（上下分割）
また、要素間の適切な余白を確保するためにgapとpaddingを追加しました。

---
*PR created automatically by Jules for task [1953763108845967070](https://jules.google.com/task/1953763108845967070) started by @mee1080*