### PR TITLE
Ramenシナリオのモック実装追加

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/Scenario.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/Scenario.kt
@@ -10,6 +10,9 @@ import io.github.mee1080.umasim.scenario.aoharu.aoharuTrainingData
 import io.github.mee1080.umasim.scenario.bc.BCCalculator
 import io.github.mee1080.umasim.scenario.bc.BCScenarioEvents
 import io.github.mee1080.umasim.scenario.bc.bcTrainingData
+import io.github.mee1080.umasim.scenario.ramen.RamenCalculator
+import io.github.mee1080.umasim.scenario.ramen.RamenScenarioEvents
+import io.github.mee1080.umasim.scenario.ramen.ramenTrainingData
 import io.github.mee1080.umasim.scenario.climax.ClimaxCalculator
 import io.github.mee1080.umasim.scenario.climax.ClimaxScenarioEvents
 import io.github.mee1080.umasim.scenario.climax.climaxTrainingData
@@ -242,6 +245,18 @@ enum class Scenario(
             "フォーエバーヤング", "マルシュロレーヌ", "カジノドライヴ",
         ),
         calculator = BCCalculator,
+    ),
+
+    RAMEN(
+        scenarioNumber = 14,
+        displayName = "ラーメン（仮）",
+        trainingData = ramenTrainingData,
+        scenarioEvents = { RamenScenarioEvents() },
+        turn = 78,
+        scenarioLink = setOf(
+            "ファインモーション",
+        ),
+        calculator = RamenCalculator,
     ),
 
     ;

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculator.kt
@@ -1,0 +1,21 @@
+package io.github.mee1080.umasim.scenario.ramen
+
+import io.github.mee1080.umasim.data.ExpectedStatus
+import io.github.mee1080.umasim.data.Status
+import io.github.mee1080.umasim.scenario.ScenarioCalculator
+import io.github.mee1080.umasim.simulation2.Calculator.CalcInfo
+
+object RamenCalculator : ScenarioCalculator {
+
+    override fun calcScenarioStatus(
+        info: CalcInfo,
+        base: Status,
+        raw: ExpectedStatus,
+        friendTraining: Boolean
+    ): Status {
+        // TODO: ラーメンシナリオ固有のステータス上昇計算を実装する
+        return Status()
+    }
+
+    override fun getScenarioCalcBonus(baseInfo: CalcInfo) = null // TODO: 必要に応じてボーナスを実装
+}

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenScenarioEvents.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenScenarioEvents.kt
@@ -1,0 +1,26 @@
+package io.github.mee1080.umasim.scenario.ramen
+
+import io.github.mee1080.umasim.scenario.BaseScenarioEvents
+import io.github.mee1080.umasim.simulation2.ActionSelector
+import io.github.mee1080.umasim.simulation2.SimulationState
+
+class RamenScenarioEvents : BaseScenarioEvents() {
+
+    override fun beforeSimulation(state: SimulationState): SimulationState {
+        return super.beforeSimulation(state).copy(
+            scenarioStatus = RamenStatus()
+        )
+    }
+
+    override suspend fun beforeAction(state: SimulationState, selector: ActionSelector): SimulationState {
+        val base = super.beforeAction(state, selector)
+        // TODO: ターンごとのシナリオイベントを実装する
+        return base
+    }
+
+    override suspend fun afterAction(state: SimulationState, selector: ActionSelector): SimulationState {
+        val base = super.afterAction(state, selector)
+        // TODO: アクション後のシナリオイベントを実装する
+        return base
+    }
+}

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenStatus.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenStatus.kt
@@ -1,0 +1,17 @@
+package io.github.mee1080.umasim.scenario.ramen
+
+import io.github.mee1080.umasim.simulation2.ScenarioStatus
+import io.github.mee1080.umasim.simulation2.SimulationState
+
+fun SimulationState.updateRamenStatus(update: RamenStatus.() -> RamenStatus): SimulationState {
+    val ramenStatus = this.ramenStatus ?: return this
+    return copy(scenarioStatus = ramenStatus.update())
+}
+
+/**
+ * Ramenシナリオ固有の状態を保持するクラス。
+ */
+data class RamenStatus(
+    // TODO: ラーメンシナリオ固有の状態を定義する
+    val ramenLevel: Int = 1,
+) : ScenarioStatus

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenStore.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenStore.kt
@@ -1,0 +1,5 @@
+package io.github.mee1080.umasim.scenario.ramen
+
+// TODO: シナリオ固有の定数やデータ（ルート、ランク文字列など）を定義する
+object RamenStore {
+}

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenTrainingData.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenTrainingData.kt
@@ -1,0 +1,34 @@
+package io.github.mee1080.umasim.scenario.ramen
+
+import io.github.mee1080.umasim.data.Status
+import io.github.mee1080.umasim.data.StatusType
+import io.github.mee1080.umasim.data.TrainingBase
+
+// TODO: ラーメンシナリオ固有のトレーニング値を設定する（暫定的にURAベース）
+val ramenTrainingData: List<TrainingBase> = listOf(
+    TrainingBase(StatusType.SPEED, 1, 520, Status(11, 0, 6, 0, 0, 4, -21)),
+    TrainingBase(StatusType.SPEED, 2, 524, Status(12, 0, 6, 0, 0, 4, -22)),
+    TrainingBase(StatusType.SPEED, 3, 528, Status(13, 0, 6, 0, 0, 4, -23)),
+    TrainingBase(StatusType.SPEED, 4, 532, Status(14, 0, 7, 0, 0, 4, -25)),
+    TrainingBase(StatusType.SPEED, 5, 536, Status(15, 0, 8, 0, 0, 4, -27)),
+    TrainingBase(StatusType.POWER, 1, 516, Status(0, 6, 9, 0, 0, 4, -20)),
+    TrainingBase(StatusType.POWER, 2, 520, Status(0, 6, 10, 0, 0, 4, -21)),
+    TrainingBase(StatusType.POWER, 3, 524, Status(0, 6, 11, 0, 0, 4, -22)),
+    TrainingBase(StatusType.POWER, 4, 528, Status(0, 7, 12, 0, 0, 4, -24)),
+    TrainingBase(StatusType.POWER, 5, 532, Status(0, 8, 13, 0, 0, 4, -26)),
+    TrainingBase(StatusType.GUTS, 1, 532, Status(5, 0, 5, 8, 0, 4, -22)),
+    TrainingBase(StatusType.GUTS, 2, 536, Status(5, 0, 5, 9, 0, 4, -23)),
+    TrainingBase(StatusType.GUTS, 3, 540, Status(5, 0, 5, 10, 0, 4, -24)),
+    TrainingBase(StatusType.GUTS, 4, 544, Status(5, 0, 5, 12, 0, 4, -26)),
+    TrainingBase(StatusType.GUTS, 5, 548, Status(6, 0, 5, 13, 0, 4, -28)),
+    TrainingBase(StatusType.STAMINA, 1, 507, Status(0, 10, 0, 6, 0, 4, -19)),
+    TrainingBase(StatusType.STAMINA, 2, 511, Status(0, 11, 0, 6, 0, 4, -20)),
+    TrainingBase(StatusType.STAMINA, 3, 515, Status(0, 12, 0, 6, 0, 4, -21)),
+    TrainingBase(StatusType.STAMINA, 4, 519, Status(0, 13, 0, 7, 0, 4, -23)),
+    TrainingBase(StatusType.STAMINA, 5, 523, Status(0, 14, 0, 8, 0, 4, -25)),
+    TrainingBase(StatusType.WISDOM, 1, 320, Status(2, 0, 0, 0, 10, 5, 5)),
+    TrainingBase(StatusType.WISDOM, 2, 321, Status(2, 0, 0, 0, 11, 5, 5)),
+    TrainingBase(StatusType.WISDOM, 3, 322, Status(2, 0, 0, 0, 12, 5, 5)),
+    TrainingBase(StatusType.WISDOM, 4, 323, Status(3, 0, 0, 0, 13, 5, 5)),
+    TrainingBase(StatusType.WISDOM, 5, 324, Status(4, 0, 0, 0, 14, 5, 5)),
+)

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/SimulationState.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/SimulationState.kt
@@ -32,6 +32,7 @@ import io.github.mee1080.umasim.scenario.live.LiveStatus
 import io.github.mee1080.umasim.scenario.mecha.MechaStatus
 import io.github.mee1080.umasim.scenario.mujinto.MujintoStatus
 import io.github.mee1080.umasim.scenario.onsen.OnsenStatus
+import io.github.mee1080.umasim.scenario.ramen.RamenStatus
 import io.github.mee1080.umasim.scenario.uaf.UafStatus
 import kotlin.math.min
 
@@ -76,6 +77,8 @@ data class SimulationState(
     val onsenStatus get() = scenarioStatus as? OnsenStatus
 
     val bcStatus get() = scenarioStatus as? BCStatus
+
+    val ramenStatus get() = scenarioStatus as? RamenStatus
 
     val supportTypeCount = supportCount.size
 


### PR DESCRIPTION
Ramenシナリオ（ID: 14）のモック実装を追加しました。
BCシナリオの実装を参考に、以下のファイルを作成・更新しました：
- RamenStatus: シナリオ固有状態の定義
- RamenCalculator: ステータス計算等のロジック
- RamenScenarioEvents: シナリオイベントのフック
- RamenStore, RamenTrainingData: 定数・データ定義
- Scenario.kt: シナリオの登録（ターン数78、ファインモーションをリンクキャラに設定）
- SimulationState.kt: RamenStatusへのアクセサを追加

詳細な仕様が不明な部分はTODOコメントを残しています。

---
*PR created automatically by Jules for task [14482220922569903954](https://jules.google.com/task/14482220922569903954) started by @mee1080*