### PR TITLE
Update duration logic for skill "超常体験"

### DIFF
--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceCalculator.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceCalculator.kt
@@ -88,6 +88,12 @@ class RaceCalculator(
 
         simulation.forceInSpeed = Random.nextDouble(0.1) * forceInFixed[umaStatus.style]!!
 
+        val finalCornerStart = trackDetail.corners.lastOrNull()?.start ?: Double.MAX_VALUE
+        simulation.supernaturalExperienceCount = min(
+            4,
+            trackDetail.slopes.count { it.slope > 0 && it.end < finalCornerStart }
+        )
+
         if (!isVirtualLeader) {
             debuffCounts.forEach { (type, count) ->
                 if (type.distanceType != null && type.distanceType != trackDetail.distanceType) return@forEach

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/calc2/RaceState.kt
@@ -851,6 +851,7 @@ class RaceSimulationState(
     var startDelayCount: Int = 0,
     var sectionTargetSpeedRandoms: Map<Int, Double> = emptyMap(),
     var evoDurationMultiplier: Double = 1.0,
+    var supernaturalExperienceCount: Int = 0,
 
     var positionCompetitionCount: Int = 0,
     var staminaKeepStart: Double = 0.0,

--- a/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/data2/SkillData.kt
+++ b/race/src/commonMain/kotlin/io/github/mee1080/umasim/race/data2/SkillData.kt
@@ -599,6 +599,7 @@ data class Invoke(
             when (durationSpecial) {
                 2 -> add("先頭との距離は最大（1.6倍）固定")
                 4 -> add("発動直後に2回追い抜く条件で近似")
+                8 -> add("上り坂を上りきった回数に応じて効果時間が増える（最大4回）")
             }
         }
     }
@@ -650,6 +651,11 @@ data class Invoke(
                     sp < 2100 -> 2.5
                     else -> 3.0
                 }
+            }
+
+            8 -> {
+                // 坂の数に応じて（超常体験）
+                duration + state.simulation.supernaturalExperienceCount * 0.5 * state.setting.timeCoef
             }
 
             else -> duration


### PR DESCRIPTION
Modified the duration calculation for the skill "超常体験" (Supernatural Experience). The duration is now increased by (number of uphill slopes before final corner * 0.5 * course distance / 1000) seconds. The count of such slopes is pre-calculated at the start of the race and capped at 4.

---
*PR created automatically by Jules for task [4779334157534463180](https://jules.google.com/task/4779334157534463180) started by @mee1080*