### PR TITLE
Implement Ramen Scenario training logic

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculator.kt
@@ -2,6 +2,8 @@ package io.github.mee1080.umasim.scenario.ramen
 
 import io.github.mee1080.umasim.data.ExpectedStatus
 import io.github.mee1080.umasim.data.Status
+import io.github.mee1080.umasim.data.StatusType
+import io.github.mee1080.umasim.data.trainingType
 import io.github.mee1080.umasim.scenario.ScenarioCalculator
 import io.github.mee1080.umasim.simulation2.*
 
@@ -13,31 +15,55 @@ object RamenCalculator : ScenarioCalculator {
         raw: ExpectedStatus,
         friendTraining: Boolean
     ): Status {
-        // TODO 計算式全般
         val ramenStatus = info.ramenStatus ?: return Status()
+        val region = ramenStatus.activeTastingRegion
 
-        var bonusRate = 0
+        var trainingBonus = 0
+        var friendFactor = 1.0
 
         // 試食会の基礎効果 (トレ効果15)
-        if (ramenStatus.activeTastingRegion != null) {
-            bonusRate += 15
+        if (region != null) {
+            trainingBonus += 15
         }
 
         // 盛り上がりPtによるボーナス (暫定: 1000ptごとにトレ効果1%?)
         val excitementBonus = (ramenStatus.excitementPt / 1000).coerceAtMost(10)
-        bonusRate += excitementBonus
-
-        var bonus = Status()
-        if (bonusRate > 0) {
-            bonus = base.multiplyToInt(bonusRate)
-        }
+        trainingBonus += excitementBonus
 
         // 地域ごとの固有効果
-        ramenStatus.activeTastingRegion?.let { region ->
-            // TODO
+        var skillPtBonus = 0
+        if (region != null) {
+            if (region.targetAll || region.targetTypes.contains(info.training.type)) {
+                trainingBonus += region.trainingEffect
+                if (friendTraining) {
+                    friendFactor *= (100 + region.friendBonus) / 100.0
+                }
+                skillPtBonus = region.skillPtTrainingEffect
+            }
         }
 
-        return bonus
+        val commonBonus = Calculator.ScenarioCalcBonus(
+            trainingBonus = trainingBonus,
+            friendFactor = friendFactor
+        )
+
+        val speed = (Calculator.calcTrainingStatus(info, StatusType.SPEED, friendTraining, bonus = commonBonus) - base.speed).toInt()
+        val stamina = (Calculator.calcTrainingStatus(info, StatusType.STAMINA, friendTraining, bonus = commonBonus) - base.stamina).toInt()
+        val power = (Calculator.calcTrainingStatus(info, StatusType.POWER, friendTraining, bonus = commonBonus) - base.power).toInt()
+        val guts = (Calculator.calcTrainingStatus(info, StatusType.GUTS, friendTraining, bonus = commonBonus) - base.guts).toInt()
+        val wisdom = (Calculator.calcTrainingStatus(info, StatusType.WISDOM, friendTraining, bonus = commonBonus) - base.wisdom).toInt()
+
+        val skillBonus = commonBonus.copy(trainingBonus = trainingBonus + skillPtBonus)
+        val skillPt = (Calculator.calcTrainingStatus(info, StatusType.SKILL, friendTraining, bonus = skillBonus) - base.skillPt).toInt()
+
+        return Status(
+            speed = speed,
+            stamina = stamina,
+            power = power,
+            guts = guts,
+            wisdom = wisdom,
+            skillPt = skillPt,
+        )
     }
 
     override fun predictScenarioAction(
@@ -60,6 +86,75 @@ object RamenCalculator : ScenarioCalculator {
             hidden >= neededHidden
         }
         return availableTasting.map { RamenTasting(it) }.toTypedArray()
+    }
+
+    override fun getAdditionalMemberCount(state: SimulationState): Int {
+        val ramenStatus = state.ramenStatus ?: return 0
+        val region = ramenStatus.activeTastingRegion ?: return 0
+        return if (region.targetAll) region.addMember else 0
+    }
+
+    override fun getForceHintCount(state: SimulationState): Int {
+        val ramenStatus = state.ramenStatus ?: return 0
+        val region = ramenStatus.activeTastingRegion ?: return 0
+        return if (region.targetAll) region.hintCount else 0
+    }
+
+    override fun modifyShuffledMember(
+        state: SimulationState,
+        member: List<MemberState>
+    ): List<MemberState> {
+        val ramenStatus = state.ramenStatus ?: return member
+        val region = ramenStatus.activeTastingRegion ?: return member
+        if (region.targetAll) return member
+
+        var currentMember = member
+        val supportPosition = trainingType.associateWith { type ->
+            currentMember.filter { it.positions.contains(type) }.toMutableList()
+        }
+
+        // hintCount logic
+        if (region.hintCount > 0) {
+            val targets = currentMember.filter {
+                !it.guest && !it.outingType && region.targetTypes.contains(it.card.type) && it.positions.isNotEmpty()
+            }
+            val notHintTargets = targets.filter { !it.hint }
+            val alreadyHintCount = targets.size - notHintTargets.size
+            val needMore = region.hintCount - alreadyHintCount
+            if (needMore > 0) {
+                val toAddIndices = notHintTargets.shuffled().take(needMore).map { it.index }.toSet()
+                currentMember = currentMember.map {
+                    if (toAddIndices.contains(it.index)) {
+                        it.copy(supportState = it.supportState?.copy(hintIcon = true))
+                    } else it
+                }
+            }
+        }
+
+        // addMember logic
+        if (region.addMember > 0) {
+            val candidates = currentMember.filter { !it.guest && it.position != StatusType.NONE }.shuffled()
+            if (candidates.isNotEmpty()) {
+                for (i in 0 until region.addMember) {
+                    val targetCandidate = candidates[i % candidates.size]
+                    val target = currentMember.first { it.index == targetCandidate.index }
+                    val possibleTrainings = region.targetTypes.filter { type ->
+                        supportPosition[type]!!.size < 5 && !target.positions.contains(type)
+                    }
+                    if (possibleTrainings.isNotEmpty()) {
+                        val selectedTraining = possibleTrainings.random()
+                        supportPosition[selectedTraining]!!.add(target)
+                        currentMember = currentMember.map {
+                            if (it.index == target.index) {
+                                it.copy(additionalPosition = it.additionalPosition + selectedTraining)
+                            } else it
+                        }
+                    }
+                }
+            }
+        }
+
+        return currentMember
     }
 
     override fun predictScenarioActionParams(


### PR DESCRIPTION
Implemented the training-related specifications for the Ramen scenario as requested.

Key changes:
- Updated `RamenCalculator` to override `calcScenarioStatus`, implementing training bonuses, friendship factors, and skill point boosts based on the active tasting region.
- Added logic for additional member placement and guaranteed hint counts by overriding `getAdditionalMemberCount`, `getForceHintCount`, and `modifyShuffledMember`.
- Ensured that regional bonuses are applied only during tasting sessions and respects the `targetAll` and `targetTypes` flags.
- Kept placeholder logic for `baseGauge` calculation and `excitementPt` bonuses as the exact formulas were noted as unknown.
- Verified that the core module compiles successfully.

---
*PR created automatically by Jules for task [11411993095287241391](https://jules.google.com/task/11411993095287241391) started by @mee1080*