### PR TITLE
Ramenシナリオのトレーニングテスト用ユーティリティの実装

### DIFF
--- a/core/src/commonTest/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculatorTest.kt
+++ b/core/src/commonTest/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculatorTest.kt
@@ -1,0 +1,108 @@
+package io.github.mee1080.umasim.scenario.ramen
+
+import io.github.mee1080.umasim.data.Status
+import io.github.mee1080.umasim.data.StatusType
+import io.github.mee1080.umasim.data.trainingType
+import io.github.mee1080.umasim.scenario.CalculatorTestBase
+import io.github.mee1080.umasim.scenario.Scenario
+import io.github.mee1080.umasim.simulation2.Calculator
+
+abstract class RamenCalculatorTest(
+    chara: Triple<String, Int, Int>,
+    supportCardList: List<Pair<String, Int>>,
+) : CalculatorTestBase(Scenario.RAMEN, chara, supportCardList) {
+
+    protected fun Calculator.CalcInfo.updateRamenStatus(action: RamenStatus.() -> RamenStatus): Calculator.CalcInfo {
+        return copy(scenarioStatus = ramenStatus?.run { action() })
+    }
+
+    fun Calculator.CalcInfo.initRamenStatus(): Calculator.CalcInfo {
+        return copy(scenarioStatus = RamenStatus())
+    }
+
+    fun Calculator.CalcInfo.setExcitementPt(pt: Int) = updateRamenStatus {
+        copy(excitementPt = pt)
+    }
+
+    fun Calculator.CalcInfo.setActiveTastingRegion(region: RamenRegion?) = updateRamenStatus {
+        copy(activeTastingRegion = region)
+    }
+
+    fun Calculator.CalcInfo.setGauges(noodle: Int, soup: Int, topping: Int) = updateRamenStatus {
+        copy(
+            gauges = mapOf(
+                RamenTipType.NOODLE to noodle,
+                RamenTipType.SOUP to soup,
+                RamenTipType.TOPPING to topping
+            )
+        )
+    }
+
+    fun Calculator.CalcInfo.setGauge(type: RamenTipType, value: Int) = updateRamenStatus {
+        copy(gauges = gauges + (type to value))
+    }
+
+    fun Calculator.CalcInfo.setTips(noodle: Int, soup: Int, topping: Int, hidden: Int) = updateRamenStatus {
+        copy(
+            tips = mapOf(
+                RamenTipType.NOODLE to noodle,
+                RamenTipType.SOUP to soup,
+                RamenTipType.TOPPING to topping,
+                RamenTipType.HIDDEN to hidden
+            )
+        )
+    }
+
+    fun Calculator.CalcInfo.setTip(type: RamenTipType, count: Int) = updateRamenStatus {
+        copy(tips = tips + (type to count))
+    }
+
+    fun Calculator.CalcInfo.setTrainingTip(vararg tips: RamenTipType) = updateRamenStatus {
+        copy(
+            trainingTip = tips.mapIndexed { index, tip ->
+                trainingType[index] to tip
+            }.toMap()
+        )
+    }
+
+    fun testRamenTraining(
+        baseCalcInfo: Calculator.CalcInfo,
+        type: StatusType,
+        level: Int,
+        support: List<Int>,
+        guestCount: Int = 0,
+        base: Status,
+        scenario: Status,
+    ) {
+        testTraining(
+            baseCalcInfo,
+            type,
+            level,
+            guestCount,
+            *support.toIntArray(),
+            base = base,
+            scenario = scenario,
+        )
+    }
+
+    fun testTastingTraining(
+        baseCalcInfo: Calculator.CalcInfo,
+        region: RamenRegion,
+        type: StatusType,
+        level: Int,
+        support: List<Int>,
+        guestCount: Int = 0,
+        base: Status,
+        scenario: Status,
+    ) {
+        testRamenTraining(
+            baseCalcInfo.setActiveTastingRegion(region),
+            type,
+            level,
+            support,
+            guestCount,
+            base = base,
+            scenario = scenario,
+        )
+    }
+}


### PR DESCRIPTION
Ramenシナリオのトレーニング計算をテストするためのユーティリティクラス `RamenCalculatorTest` を実装しました。
`BCCalculatorTest` と同等の機能を持ち、盛り上がりPt、試食会地域、各種ゲージやコツの設定、および通常トレーニングと試食会中トレーニングのテスト用関数を含んでいます。
ご指示通り、現時点ではチームメンバー（teamMember）に関する実装は除外しています。

---
*PR created automatically by Jules for task [1095331023856330216](https://jules.google.com/task/1095331023856330216) started by @mee1080*