### PR TITLE
Implement Ramen scenario training UI

### DIFF
--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/RamenTrainingSetting.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/RamenTrainingSetting.kt
@@ -1,0 +1,85 @@
+package io.github.mee1080.umasim.web.page.top.setting
+
+import androidx.compose.runtime.Composable
+import io.github.mee1080.umasim.scenario.Scenario
+import io.github.mee1080.umasim.scenario.ramen.RamenRegion
+import io.github.mee1080.umasim.scenario.ramen.ramenRegionSelection
+import io.github.mee1080.umasim.web.components.atoms.*
+import io.github.mee1080.umasim.web.components.parts.DivFlexCenter
+import io.github.mee1080.umasim.web.components.parts.NestedHideBlock
+import io.github.mee1080.umasim.web.components.parts.SliderEntry
+import io.github.mee1080.umasim.web.state.RamenState
+import io.github.mee1080.umasim.web.vm.ViewModel
+import org.jetbrains.compose.web.css.*
+import org.jetbrains.compose.web.dom.*
+
+@Composable
+fun RamenTrainingSetting(model: ViewModel, state: RamenState) {
+    NestedHideBlock(Scenario.RAMEN.displayName) {
+        H4 { Text("時期") }
+        DivFlexCenter({
+            style {
+                flexWrap(FlexWrap.Wrap)
+                rowGap(8.px)
+            }
+        }) {
+            listOf(
+                "ジュニア" to 1,
+                "クラシック" to 25,
+                "シニア" to 49,
+                "ファイナルズ" to 73
+            ).forEach { (label, turn) ->
+                Label(attrs = {
+                    style {
+                        marginRight(16.px)
+                        display(DisplayStyle.Flex)
+                        alignItems(AlignItems.Center)
+                        cursor("pointer")
+                    }
+                }) {
+                    MdRadio(state.turn == turn) {
+                        onSelect {
+                            model.updateRamen {
+                                val nextPeriod = (turn - 1) / 24
+                                val currentPeriod = (this.turn - 1) / 24
+                                val nextRegion = if (nextPeriod == currentPeriod) activeTastingRegion else null
+                                copy(turn = turn, activeTastingRegion = nextRegion)
+                            }
+                        }
+                    }
+                    Text(label)
+                }
+            }
+        }
+
+        SliderEntry("盛り上がりPt：", state.excitementPt, 0, 5000, 250) {
+            model.updateRamen { copy(excitementPt = it.toInt()) }
+        }
+
+        H4 { Text("試食会地域") }
+        val period = (state.turn - 1) / 24
+        val selection = ramenRegionSelection[period]
+
+        // MdFilledSelect requires non-null T. Using a wrapper or just filtering nulls.
+        // But we want "None" (null) to be selectable.
+        // Let's use RamenRegion enum name and "none" as values.
+
+        MdFilledSelect(
+            selection = listOf("none") + selection.map { it.name },
+            selectedItem = state.activeTastingRegion?.name ?: "none",
+            attrs = {
+                label("地域を選択")
+                style { width(100.percent) }
+            },
+            onSelect = { name ->
+                val region = selection.firstOrNull { it.name == name }
+                model.updateRamen { copy(activeTastingRegion = region) }
+            },
+            itemToValue = { it },
+            itemToDisplayText = { name ->
+                if (name == "none") "なし"
+                else selection.first { it.name == name }.let { "【${it.displayName}】${it.ramenName}" }
+            }
+        )
+    }
+}

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/TrainingSetting.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/setting/TrainingSetting.kt
@@ -76,5 +76,8 @@ fun TrainingSetting(model: ViewModel, state: State) {
         if (state.scenario == Scenario.BC) {
             BcTrainingSetting(model, state.bcState)
         }
+        if (state.scenario == Scenario.RAMEN) {
+            RamenTrainingSetting(model, state.ramenState)
+        }
     }
 }

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/RamenState.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/RamenState.kt
@@ -1,0 +1,28 @@
+package io.github.mee1080.umasim.web.state
+
+import io.github.mee1080.umasim.scenario.ramen.*
+
+data class RamenState(
+    val turn: Int = 1,
+    val excitementPt: Int = 0,
+    val activeTastingRegion: RamenRegion? = null,
+) {
+    fun toRamenStatus(): RamenStatus {
+        val period = (turn - 1) / 24
+        val rmjBonus = if (period == 0) {
+            RamenBaseBonus(0, 0, 0, 0)
+        } else {
+            ramenRmjBonus[period - 1][1]
+        }
+        val targetExcitePt = ramenTargetExcitePt[period]
+        val regionRank = (excitementPt * 5 / targetExcitePt).coerceAtMost(5)
+        val regionRankBonus = ramenRegionRankBonus[regionRank]
+
+        return RamenStatus(
+            turn = turn,
+            excitementPt = excitementPt,
+            activeTastingRegion = activeTastingRegion?.let { it to regionRankBonus },
+            rmjBonus = rmjBonus
+        )
+    }
+}

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
@@ -95,6 +95,7 @@ data class State(
     val mechaState: MechaState = MechaState(),
     val mujintoState: MujintoState = MujintoState(),
     val bcState: BCState = BCState(),
+    val ramenState: RamenState = RamenState(),
 ) {
 
     val supportFilterApplied get() = supportFilter == appliedSupportFilter
@@ -156,6 +157,7 @@ data class State(
             ?: mechaStatusIfEnabled
             ?: mujintoStatusIfEnabled
             ?: bcStatusIfEnabled
+            ?: ramenStatusIfEnabled
 
     val trainingLiveStateIfEnabled get() = if (scenario == Scenario.GRAND_LIVE) trainingLiveState else null
 
@@ -175,6 +177,8 @@ data class State(
     val mujintoStatusIfEnabled get() = if (scenario == Scenario.MUJINTO) mujintoState.toMujintoStatus() else null
 
     val bcStatusIfEnabled get() = if (scenario == Scenario.BC) bcState.toBCStatus(selectedTrainingType) else null
+
+    val ramenStatusIfEnabled get() = if (scenario == Scenario.RAMEN) ramenState.toRamenStatus() else null
 
     val specialityRateUp
         get() = when (scenario) {

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
@@ -826,4 +826,8 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
     fun updateBC(update: BCState.() -> BCState) {
         update { copy(bcState = bcState.update()) }
     }
+
+    fun updateRamen(update: RamenState.() -> RamenState) {
+        update { copy(ramenState = ramenState.update()) }
+    }
 }


### PR DESCRIPTION
Ramenシナリオ（らっしゃい！トレセン軒！）のトレーニング計算UIをwebモジュールに実装しました。

主な変更点：
- `RamenState.kt`: シナリオ固有の状態（ターン、盛り上がりPt、試食会地域）を管理するクラスの作成
- `State.kt`, `ViewModel.kt`: `RamenState` の保持と更新処理の追加
- `RamenTrainingSetting.kt`: 時期選択（ラジオボタン）、盛り上がりPt（スライダー）、試食会地域（セレクトボックス）を含むUIコンポーネントの実装
- `TrainingSetting.kt`: 既存のトレーニング設定画面への組み込み

全ての変更はコンパイル確認済みであり、Playwrightを用いたブラウザ上での動作確認も実施しました。

---
*PR created automatically by Jules for task [17725946705760588698](https://jules.google.com/task/17725946705760588698) started by @mee1080*