### PR TITLE
Ramen scenario tasting and turn-start bonuses

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculator.kt
@@ -132,57 +132,7 @@ object RamenCalculator : ScenarioCalculator {
         state: SimulationState,
         member: List<MemberState>
     ): List<MemberState> {
-        val ramenStatus = state.ramenStatus ?: return member
-        val region = ramenStatus.activeTastingRegion?.first ?: return member
-        if (region.targetAll) return member
-
-        var currentMember = member
-        val supportPosition = trainingType.associateWith { type ->
-            currentMember.filter { it.positions.contains(type) }.toMutableList()
-        }
-
-        // hintCount logic
-        if (region.hintCount > 0) {
-            val targets = currentMember.filter {
-                !it.guest && !it.outingType && region.targetTypes.contains(it.card.type) && it.positions.isNotEmpty()
-            }
-            val notHintTargets = targets.filter { !it.hint }
-            val alreadyHintCount = targets.size - notHintTargets.size
-            val needMore = region.hintCount - alreadyHintCount
-            if (needMore > 0) {
-                val toAddIndices = notHintTargets.shuffled().take(needMore).map { it.index }.toSet()
-                currentMember = currentMember.map {
-                    if (toAddIndices.contains(it.index)) {
-                        it.copy(supportState = it.supportState?.copy(hintIcon = true))
-                    } else it
-                }
-            }
-        }
-
-        // addMember logic
-        if (region.addMember > 0) {
-            val candidates = currentMember.filter { !it.guest && it.position != StatusType.NONE }.shuffled()
-            if (candidates.isNotEmpty()) {
-                for (i in 0 until region.addMember) {
-                    val targetCandidate = candidates[i % candidates.size]
-                    val target = currentMember.first { it.index == targetCandidate.index }
-                    val possibleTrainings = region.targetTypes.filter { type ->
-                        supportPosition[type]!!.size < 5 && !target.positions.contains(type)
-                    }
-                    if (possibleTrainings.isNotEmpty()) {
-                        val selectedTraining = possibleTrainings.random()
-                        supportPosition[selectedTraining]!!.add(target)
-                        currentMember = currentMember.map {
-                            if (it.index == target.index) {
-                                it.copy(additionalPosition = it.additionalPosition + selectedTraining)
-                            } else it
-                        }
-                    }
-                }
-            }
-        }
-
-        return currentMember
+        return member
     }
 
     override fun predictScenarioActionParams(
@@ -212,20 +162,55 @@ object RamenCalculator : ScenarioCalculator {
 
     fun applyScenarioAction(state: SimulationState, result: ActionResult): SimulationState {
         return when (result) {
-            is RamenSelectRegionResult -> {
-                state.updateRamenStatus {
-                    addRegion(result.region)
-                }
-            }
-
-            is RamenTastingResult -> {
-                state.updateRamenStatus {
-                    activateTasting(result.region)
-                }
-            }
-
+            is RamenSelectRegionResult -> applyRamenSelectRegionResult(state, result)
+            is RamenTastingResult -> applyRamenTastingResult(state, result)
             else -> state
         }
+    }
+
+    private fun applyRamenSelectRegionResult(state: SimulationState, result: RamenSelectRegionResult): SimulationState {
+        return state.updateRamenStatus {
+            addRegion(result.region)
+        }
+    }
+
+    private fun applyRamenTastingResult(state: SimulationState, result: RamenTastingResult): SimulationState {
+        val region = result.region
+        var newState = state.updateRamenStatus {
+            activateTasting(region)
+        }
+
+        // hintCount: targetTypesのサポカのヒント獲得
+        repeat(region.hintCount) {
+            newState = newState.addRandomSupportHint(region.targetTypes, hintLevel = 2)
+        }
+
+        // addMember: targetTypesのトレーニングに、未参加のサポートカードを1種追加で参加させる
+        repeat(region.addMember) {
+            val candidates = newState.member.filter { !it.guest && it.positions.isEmpty() }
+            val targetCard = candidates.randomOrNull() ?: return@repeat
+            val targetTypes = if (region.targetAll) trainingType.toList() else region.targetTypes
+            val supportCount = trainingType.associateWith { type ->
+                newState.member.count { it.positions.contains(type) }
+            }
+            val availableTypes = targetTypes.filter { (supportCount[it] ?: 0) < 5 }
+            val targetType = availableTypes.randomOrNull() ?: return@repeat
+
+            newState = newState.copy(
+                member = newState.member.map {
+                    if (it.index == targetCard.index) {
+                        it.copy(additionalPosition = it.additionalPosition + targetType)
+                    } else it
+                }
+            )
+        }
+
+        // hintSkill: 極のヒント獲得
+        if (region.hintSkill.isNotEmpty()) {
+            newState = newState.addStatus(Status(skillHint = mapOf(region.hintSkill to 2)))
+        }
+
+        return newState
     }
 
     fun applyScenarioActionParam(state: SimulationState, param: RamenActionParam): SimulationState {

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenScenarioEvents.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenScenarioEvents.kt
@@ -13,7 +13,10 @@ class RamenScenarioEvents : BaseScenarioEvents() {
     }
 
     override suspend fun beforeAction(state: SimulationState, selector: ActionSelector): SimulationState {
-        val base = state.updateRamenStatus { shuffleTrainingTip() }
+        var base = state.updateRamenStatus { shuffleTrainingTip() }
+        if (base.turn >= 73) {
+            base = base.addStatus(Status(hp = 20, motivation = 1))
+        }
         val current = when (base.turn) {
             1 -> base.selectRamenRegion(selector, 0)
 

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/SimulationStateUpdater.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/SimulationStateUpdater.kt
@@ -486,7 +486,12 @@ private fun SimulationState.selectTrainingHint(
     }
 }
 
-private fun MemberState.selectHint(currentStatus: Status, count: Int = 1, hintCountUpEnabled: Boolean = true): Status {
+private fun MemberState.selectHint(
+    currentStatus: Status,
+    count: Int = 1,
+    hintCountUpEnabled: Boolean = true,
+    hintLevel: Int? = null,
+): Status {
     var result = Status()
     repeat(count + (if (hintCountUpEnabled) card.hintCountUp(relation) else 0)) {
         val hintSkill = (card.skills.filter {
@@ -495,7 +500,7 @@ private fun MemberState.selectHint(currentStatus: Status, count: Int = 1, hintCo
         result += if (hintSkill.isEmpty()) {
             card.hintStatus
         } else {
-            Status(skillHint = mapOf(hintSkill to 1 + card.hintLevel))
+            Status(skillHint = mapOf(hintSkill to (hintLevel ?: (1 + card.hintLevel))))
         }
     }
     return result
@@ -951,9 +956,14 @@ fun SimulationState.addNextTurnSpecialityRateUpAll(rate: Int): SimulationState {
     return copy(member = member.map { it.addNextTurnSpecialityRateUp(rate) })
 }
 
-fun SimulationState.addRandomSupportHint(): SimulationState {
-    val target = support.filter { !it.outingType }.randomOrNull() ?: return this
-    return addStatus(target.selectHint(status))
+fun SimulationState.addRandomSupportHint(
+    targetTypes: List<StatusType>? = null,
+    hintLevel: Int? = null,
+): SimulationState {
+    val target = support.filter {
+        !it.outingType && (targetTypes == null || targetTypes.contains(it.card.type))
+    }.randomOrNull() ?: return this
+    return addStatus(target.selectHint(status, hintLevel = hintLevel))
 }
 
 fun SimulationState.addAllSupportHint(): SimulationState {


### PR DESCRIPTION
Implement missing Ramen scenario logic for tasting results and turn 73+ bonuses. This includes specialized hint acquisition, additional support card placement in training, and specific skill hint rewards, as well as turn-based status improvements.

---
*PR created automatically by Jules for task [888919627989108889](https://jules.google.com/task/888919627989108889) started by @mee1080*