### PR TITLE
Add "Tasting Event Increase" display for Ramen scenario

### DIFF
--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
@@ -370,6 +370,64 @@ fun TrainingInfo(model: ViewModel, state: State) {
                 Div { Text("※計算式： 上昇量 - 対象カードが練習不参加時の上昇量") }
             }
         }
+        if (state.scenario == Scenario.RAMEN && state.ramenTastingImpact.isNotEmpty()) {
+            NestedHideBlock("試食会上昇量") {
+                Div {
+                    Table({ classes(AppStyle.table) }) {
+                        Tr {
+                            Th({
+                                style {
+                                    property("border", "none")
+                                }
+                                unsetWidth()
+                            }) { }
+                            Th { Text("スピード") }
+                            Th { Text("スタミナ") }
+                            Th { Text("パワー") }
+                            Th { Text("根性") }
+                            Th { Text("賢さ") }
+                            Th { Text("スキルPt") }
+                            Th { Text("体力") }
+                            Th { Text("5ステ合計") }
+                            Th { Text("5ステ+SP") }
+                        }
+                        state.ramenTastingImpact.forEach { (name, status, impact) ->
+                            Tr {
+                                Td({
+                                    unsetWidth()
+                                    style { fontWeight("bold") }
+                                }) { Text(name) }
+                                Td { Text(status.speed.toString()) }
+                                Td { Text(status.stamina.toString()) }
+                                Td { Text(status.power.toString()) }
+                                Td { Text(status.guts.toString()) }
+                                Td { Text(status.wisdom.toString()) }
+                                Td { Text(status.skillPt.toString()) }
+                                Td { Text(status.hp.toString()) }
+                                Td { Text(status.statusTotal.toString()) }
+                                Td { Text(status.totalPlusSkillPt.toString()) }
+                            }
+                            Tr {
+                                Td({
+                                    unsetWidth()
+                                    style { textAlign("right") }
+                                }) { Text("(増分)") }
+                                Td { Text(impact.speed.toString()) }
+                                Td { Text(impact.stamina.toString()) }
+                                Td { Text(impact.power.toString()) }
+                                Td { Text(impact.guts.toString()) }
+                                Td { Text(impact.wisdom.toString()) }
+                                Td { Text(impact.skillPt.toString()) }
+                                Td { Text(impact.hp.toString()) }
+                                Td { Text(impact.statusTotal.toString()) }
+                                Td { Text(impact.totalPlusSkillPt.toString()) }
+                            }
+                        }
+                    }
+                }
+                Div { Text("※計算式： 参加した場合の上昇量 / 試食会なしの上昇量からの増分") }
+            }
+        }
         H3 { Text("友情トレーニング発生率: ${(state.friendProbability * 10000.0).roundToInt() / 100.0}%") }
         NestedHideBlock("期待値（練習配置率を考慮）") {
             Div {

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
@@ -74,6 +74,7 @@ data class State(
     val trainingPerformanceValue: Int = 0,
     val rawTrainingResult: ExpectedStatus = ExpectedStatus(),
     val trainingImpact: List<Pair<String, Status>> = emptyList(),
+    val ramenTastingImpact: List<RamenTastingImpact> = emptyList(),
     val expectedResult: ExpectedStatus = ExpectedStatus(),
     val upperRate: Double = 0.0,
     val friendProbability: Double = 0.0,
@@ -187,6 +188,12 @@ data class State(
             else -> 0
         }
 }
+
+data class RamenTastingImpact(
+    val name: String,
+    val status: Status,
+    val impact: Status,
+)
 
 data class SupportSelection(
     val selectedSupport: Int = WebConstants.notSelected.first,

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
@@ -402,6 +402,29 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
             target.name to trainingResult.first.first + trainingResult.second - notJoinResult.first.first - notJoinResult.second
         }
 
+        val ramenTastingImpact = if (state.scenario == Scenario.RAMEN && state.ramenState.turn in 25..72 && state.ramenState.activeTastingRegion != null) {
+            val ramenStatus = scenarioStatus as? io.github.mee1080.umasim.scenario.ramen.RamenStatus
+            if (ramenStatus != null) {
+                val noTastingStatus = ramenStatus.copy(activeTastingRegion = null)
+                allSupportList.filter { support ->
+                    !joinSupportList.any { it.index == support.index } && !support.card.type.outingType
+                }.map { support ->
+                    val withSupportJoinList = joinSupportList + support
+                    val withSupportInfo = trainingCalcInfo.copy(member = withSupportJoinList)
+                    val s1 = Calculator.calcTrainingSuccessStatusSeparated(
+                        withSupportInfo,
+                        state.scenario.calculator.getScenarioCalcBonus(withSupportInfo)
+                    ).let { it.first.first + it.second }
+                    val withSupportNoTastingInfo = withSupportInfo.copy(scenarioStatus = noTastingStatus)
+                    val s2 = Calculator.calcTrainingSuccessStatusSeparated(
+                        withSupportNoTastingInfo,
+                        state.scenario.calculator.getScenarioCalcBonus(withSupportNoTastingInfo)
+                    ).let { it.first.first + it.second }
+                    RamenTastingImpact(support.name, s1, s1 - s2)
+                }
+            } else emptyList()
+        } else emptyList()
+
         val supportList = state.supportSelectionList.mapIndexedNotNull { index, support ->
             support.toMemberState(state.scenario, index)
         }
@@ -474,6 +497,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
             trainingPerformanceValue = trainingPerformanceValue,
             rawTrainingResult = trainingResult.first.second,
             trainingImpact = trainingImpact,
+            ramenTastingImpact = ramenTastingImpact,
             expectedResult = expectedResult.first,
             upperRate = upperRate,
 //            coinRate = coinRate,


### PR DESCRIPTION
This change adds a new feature to the Ramen scenario training calculator in the web module. It displays a table of hypothetical status gains if non-participating support cards were to join the training, highlighting the specific contribution of the currently active "Tasting Event". This only shows during Classic and Senior periods when a region is selected.

---
*PR created automatically by Jules for task [2698632260969487987](https://jules.google.com/task/2698632260969487987) started by @mee1080*