### PR TITLE
Ramenシナリオ：全パターン計算機能の追加

### DIFF
--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
@@ -384,6 +384,46 @@ fun TrainingInfo(model: ViewModel, state: State) {
                 }
             }
             Div { Text("※計算式： 参加した場合の上昇量 - 試食会なしの上昇量") }
+
+            MdFilledButton("全パターン計算", attrs = {
+                onClick { model.calculateRamenAllPatterns() }
+                style { marginTop(8.px) }
+            })
+
+            if (state.ramenAllTastingImpact.isNotEmpty()) {
+                Div({ style { marginTop(16.px) } }) {
+                    Table({ classes(AppStyle.table) }) {
+                        Tr {
+                            Th { Text("参加サポート") }
+                            Th { Text("追加") }
+                            Th { Text("スピード") }
+                            Th { Text("スタミナ") }
+                            Th { Text("パワー") }
+                            Th { Text("根性") }
+                            Th { Text("賢さ") }
+                            Th { Text("スキルPt") }
+                            Th { Text("体力") }
+                            Th { Text("5ステ合計") }
+                            Th { Text("5ステ+SP") }
+                        }
+                        state.ramenAllTastingImpact.forEach { impact ->
+                            Tr {
+                                Td { Text(impact.participants.joinToString(", ")) }
+                                Td { Text(impact.added) }
+                                Td { Text(impact.impact.speed.toString()) }
+                                Td { Text(impact.impact.stamina.toString()) }
+                                Td { Text(impact.impact.power.toString()) }
+                                Td { Text(impact.impact.guts.toString()) }
+                                Td { Text(impact.impact.wisdom.toString()) }
+                                Td { Text(impact.impact.skillPt.toString()) }
+                                Td { Text(impact.impact.hp.toString()) }
+                                Td { Text(impact.impact.statusTotal.toString()) }
+                                Td { Text(impact.impact.totalPlusSkillPt.toString()) }
+                            }
+                        }
+                    }
+                }
+            }
         }
         if (state.trainingImpact.isNotEmpty()) {
             NestedHideBlock("サポカ影響度") {

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
@@ -75,6 +75,7 @@ data class State(
     val rawTrainingResult: ExpectedStatus = ExpectedStatus(),
     val trainingImpact: List<Pair<String, Status>> = emptyList(),
     val ramenTastingImpact: List<RamenTastingImpact> = emptyList(),
+    val ramenAllTastingImpact: List<RamenAllTastingImpact> = emptyList(),
     val expectedResult: ExpectedStatus = ExpectedStatus(),
     val upperRate: Double = 0.0,
     val friendProbability: Double = 0.0,
@@ -192,6 +193,12 @@ data class State(
 data class RamenTastingImpact(
     val name: String,
     val status: Status,
+    val impact: Status,
+)
+
+data class RamenAllTastingImpact(
+    val participants: List<String>,
+    val added: String,
     val impact: Status,
 )
 

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
@@ -78,6 +78,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
         scope.launch {
             var newState = update(state)
             if (calculate) {
+                newState = newState.copy(ramenAllTastingImpact = emptyList())
                 newState = calculate(newState)
                 newState = calculateBonus(newState)
             }
@@ -89,6 +90,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
         withContext(Dispatchers.Main) {
             var newState = update(state)
             if (calculate) {
+                newState = newState.copy(ramenAllTastingImpact = emptyList())
                 newState = calculate(newState)
                 newState = calculateBonus(newState)
             }
@@ -857,5 +859,92 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
 
     fun updateRamen(update: RamenState.() -> RamenState) {
         update { copy(ramenState = ramenState.update()) }
+    }
+
+    fun calculateRamenAllPatterns() {
+        val state = state
+        if (state.scenario != Scenario.RAMEN) return
+        val ramenStatus = state.scenarioStatus as? RamenStatus ?: return
+        val region = state.ramenState.activeTastingRegion ?: return
+        val trainingType = state.selectedTrainingTypeForScenario
+        if (!(region.targetAll || region.targetTypes.contains(trainingType))) return
+
+        scope.launch(Dispatchers.Default) {
+            val allSupportList = state.supportSelectionList.filter { it.card != null }
+                .mapIndexedNotNull { index, support -> support.toMemberState(state.scenario, index) }
+
+            val supportCount =
+                state.supportSelectionList.mapNotNull { it.card?.type }.groupBy { it }.mapValues { it.value.size }
+
+            val trainingLevel = if (state.isLevelUpTurn) 5 else state.trainingLevel
+            val trainingBase = WebConstants.trainingList[state.scenario]!!.first {
+                it.type == trainingType && it.level == trainingLevel
+            }
+
+            val baseInfo = Calculator.CalcInfo(
+                state.chara,
+                trainingBase,
+                state.motivation,
+                emptyList(),
+                state.scenario,
+                supportCount,
+                state.fanCount,
+                Status(maxHp = state.maxHp, hp = state.hp),
+                state.totalRelation,
+                state.speedSkillCount,
+                state.healSkillCount,
+                state.accelSkillCount,
+                state.totalTrainingLevel,
+                state.isLevelUpTurn,
+                ramenStatus,
+            ).setTeamMember(state.teamJoinCount)
+
+            val noTastingStatus = ramenStatus.copy(activeTastingRegion = null)
+            val scenarioCalculator = state.scenario.calculator
+
+            val results = mutableListOf<RamenAllTastingImpact>()
+            val n = allSupportList.size
+            for (i in 0 until (1 shl n)) {
+                val P = mutableListOf<MemberState>()
+                val remaining = mutableListOf<MemberState>()
+                for (j in 0 until n) {
+                    if ((i shr j) and 1 == 1) {
+                        P.add(allSupportList[j])
+                    } else {
+                        remaining.add(allSupportList[j])
+                    }
+                }
+
+                if (P.size > 4) continue
+
+                val s2Info = baseInfo.copy(member = P, scenarioStatus = noTastingStatus)
+                val s2 = Calculator.calcTrainingSuccessStatusSeparated(
+                    s2Info,
+                    scenarioCalculator.getScenarioCalcBonus(s2Info)
+                ).let { it.first.first + it.second }
+
+                for (u in remaining) {
+                    if (u.card.type.outingType) continue
+
+                    val s1Info = baseInfo.copy(member = P + u, scenarioStatus = ramenStatus)
+                    val s1 = Calculator.calcTrainingSuccessStatusSeparated(
+                        s1Info,
+                        scenarioCalculator.getScenarioCalcBonus(s1Info)
+                    ).let { it.first.first + it.second }
+
+                    results.add(
+                        RamenAllTastingImpact(
+                            participants = P.map { it.charaName },
+                            added = u.charaName,
+                            impact = s1 - s2
+                        )
+                    )
+                }
+            }
+
+            withContext(Dispatchers.Main) {
+                updateState(calculate = false) { it.copy(ramenAllTastingImpact = results) }
+            }
+        }
     }
 }


### PR DESCRIPTION
Ramenシナリオのトレーニング計算機において、試食会が発生した場合の全パターンの上昇量差分を一括計算する機能を追加しました。

主な変更点:
1. **Stateの拡張**: 計算結果を保持するための `ramenAllTastingImpact` を `State` クラスに追加しました。
2. **ViewModelへのロジック追加**: `calculateRamenAllPatterns` メソッドを実装しました。このメソッドは、デッキ内のサポートカードから参加人数4人以下のすべての組み合わせ（P）に対して、不参加のサポートカード（U）を1枚追加し、試食会あり（P+U）と試食会なし（Pのみ）の上昇量の差分を計算します。
3. **UIの統合**: `TrainingInfo.kt` に「全パターン計算」ボタンを追加しました。このボタンをクリックすると一括計算が実行され、結果が専用のテーブルに一覧表示されます。各行には参加サポートの名前（charaName）と追加されたサポート、および各ステータスの増分が表示されます。

この機能により、試食会ボーナスがどの組み合わせで最も効果的かを容易に比較できるようになります。

---
*PR created automatically by Jules for task [2899595650975435557](https://jules.google.com/task/2899595650975435557) started by @mee1080*