### PR TITLE
Implement Ramen Scenario Simulation UI in Web Module

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenStatus.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenStatus.kt
@@ -57,7 +57,7 @@ data class RamenStatus(
             RamenTipType.SOUP, RamenTipType.SOUP,
             RamenTipType.TOPPING, RamenTipType.TOPPING,
         ).shuffled()
-        val newTrainingTip = (0..5).associate {
+        val newTrainingTip = trainingType.indices.associate {
             trainingType[it] to tipList[it]
         }
         return copy(trainingTip = newTrainingTip)

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/Simulator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/Simulator.kt
@@ -69,7 +69,7 @@ class Simulator(
             fanCount = 1,
         ) + chara.initialStatus + supportCardList
             .map { target -> target.initialStatus(supportCardList.map { it.type }) }
-            .reduce { acc, status -> acc + status },
+            .fold(Status()) { acc, status -> acc + status },
         supportCount = supportCardList.groupBy { it.type }.mapValues { it.value.size },
         totalRaceBonus = supportCardList.sumOf { it.race },
         totalFanBonus = supportCardList.sumOf { it.fan },

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/simulation/RamenStateBlock.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/simulation/RamenStateBlock.kt
@@ -1,0 +1,56 @@
+package io.github.mee1080.umasim.web.page.simulation
+
+import androidx.compose.runtime.Composable
+import io.github.mee1080.umasim.scenario.ramen.*
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Text
+
+@Composable
+fun RamenStateBlock(ramenStatus: RamenStatus) {
+    Div {
+        Text("調理Pt: ${ramenStatus.excitementPt} / ${ramenStatus.targetExcitePt} (地区ランク: ${ramenStatus.regionRank}、ランクボーナス: +${ramenStatus.regionRankBonus}%)")
+    }
+    Div {
+        val regionsText = if (ramenStatus.selectedRegions.isEmpty()) {
+            "未選択"
+        } else {
+            ramenStatus.selectedRegions.joinToString(" -> ") { it.displayName }
+        }
+        Text("選択中の地区: $regionsText")
+    }
+    Div {
+        val gaugesText = RamenTipType.entries.filter { it != RamenTipType.HIDDEN }.joinToString(", ") {
+            "${it.displayName}: ${ramenStatus.gauges[it] ?: 0}/7"
+        }
+        Text("ゲージ状況 - $gaugesText")
+    }
+    Div {
+        val tipsText = RamenTipType.entries.joinToString(", ") {
+            "${it.displayName}: ${ramenStatus.tips[it] ?: 0}"
+        }
+        Text("所持している調理のコツ - $tipsText")
+    }
+    if (ramenStatus.tipHistory.isNotEmpty()) {
+        Div {
+            Text("コツ獲得履歴: " + ramenStatus.tipHistory.joinToString(" -> ") { it.displayName })
+        }
+    }
+    Div {
+        val activeTastingText = ramenStatus.activeTastingRegion?.let { (region, bonus) ->
+            "${region.displayName} (ランクボーナス: +${bonus}%)"
+        } ?: "なし"
+        Text("発動中の試食効果: $activeTastingText")
+    }
+    if (ramenStatus.trainingTip.isNotEmpty()) {
+        Div {
+            val trainingTipText = ramenStatus.trainingTip.entries.joinToString(", ") {
+                "${it.key.displayName}: ${it.value.displayName}"
+            }
+            Text("トレーニングコツ配置: $trainingTipText")
+        }
+    }
+    Div {
+        val rmj = ramenStatus.rmjBonus
+        Text("RMJボーナス - トレーニング効果: +${rmj.trainingEffect}%, 友情ボーナス: +${rmj.friendBonus}%, 得意率アップ: +${rmj.specialityRateUp}, ヒント発生率アップ: +${rmj.hintRateUp}%")
+    }
+}

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/simulation/SelectionBlock.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/simulation/SelectionBlock.kt
@@ -64,10 +64,15 @@ fun SelectionBlock(
         }
         selection.forEachIndexed { index, action ->
             val uafStatus = state.uafStatus
+            val ramenStatus = state.ramenStatus
             val (actionName, uafAthletic, uafAthleticLevel) = if (uafStatus != null && action is Training) {
                 val athletic = uafStatus.trainingAthletics[action.type]!!
                 val level = uafStatus.athleticsLevel[athletic]!!
                 Triple("トレーニング(${action.type.displayName}/${athletic.longDisplayName}Lv$level)", athletic, level)
+            } else if (ramenStatus != null && action is Training) {
+                val tip = ramenStatus.trainingTip[action.type]
+                val suffix = if (tip != null) " / ${tip.displayName}" else ""
+                Triple("トレーニング(${action.type.displayName}$suffix)", null, 0)
             } else Triple(action.name, null, 0)
             Card({
                 style {
@@ -96,6 +101,7 @@ fun SelectionBlock(
                         CookMaterialInfo(action)
                         LegendInfo(action)
                         OnsenInfo(action)
+                        RamenInfo(action)
                     }
 
                     is Race -> {
@@ -103,6 +109,7 @@ fun SelectionBlock(
                         LegendInfo(action)
                         MujintoInfo(action)
                         OnsenInfo(action)
+                        RamenInfo(action)
                         StatusTable(action.result.status)
                     }
 
@@ -120,6 +127,7 @@ fun SelectionBlock(
                         CookMaterialInfo(action)
                         LegendInfo(action)
                         OnsenInfo(action)
+                        RamenInfo(action)
                     }
 
                     is Training -> {
@@ -129,6 +137,7 @@ fun SelectionBlock(
                         MujintoInfo(action)
                         OnsenInfo(action)
                         BCInfo(action)
+                        RamenInfo(action)
                         if (uafStatus != null && uafAthletic != null) {
                             val actionResult = action.candidates[0].first as? StatusActionResult
                             val param = actionResult?.scenarioActionParam as UafScenarioActionParam?
@@ -244,9 +253,47 @@ fun SelectionBlock(
 
                     is BCTeamParameterUp -> {}
 
-                    is RamenSelectRegion -> {}
+                    is RamenSelectRegion -> {
+                        val reg = action.region
+                        Div {
+                            Text("試食コスト - 麺: ${reg.noodle}, スープ: ${reg.soup}, トッピング: ${reg.topping}")
+                        }
+                        Div {
+                            val effects = buildList {
+                                if (reg.targetTypes.isNotEmpty()) add("対象：${reg.targetTypes.joinToString("/") { it.displayName }}")
+                                if (reg.trainingEffect > 0) add("トレーニング効果: +${reg.trainingEffect}%")
+                                if (reg.skillPtTrainingEffect > 0) add("スキルPt効果: +${reg.skillPtTrainingEffect}%")
+                                if (reg.friendBonus > 0) add("友情ボーナス: +${reg.friendBonus}%")
+                                if (reg.hintCount > 0) add("ヒント獲得数: +${reg.hintCount}")
+                                if (reg.addMember > 0) add("サポカ追加配置: +${reg.addMember}")
+                                if (reg.targetAll) add("全トレーニング対象")
+                                if (reg.targetStatusLimitOver > 0) add("上限突破: +${reg.targetStatusLimitOver}")
+                                if (reg.hintSkill.isNotEmpty()) add("スキルヒント: ${reg.hintSkill}")
+                            }
+                            Text("試食効果：${effects.joinToString(", ")}")
+                        }
+                    }
 
-                    is RamenTasting -> {}
+                    is RamenTasting -> {
+                        val reg = action.region
+                        Div {
+                            Text("試食コスト - 麺: ${reg.noodle}, スープ: ${reg.soup}, トッピング: ${reg.topping}")
+                        }
+                        Div {
+                            val effects = buildList {
+                                if (reg.targetTypes.isNotEmpty()) add("対象：${reg.targetTypes.joinToString("/") { it.displayName }}")
+                                if (reg.trainingEffect > 0) add("トレーニング効果: +${reg.trainingEffect}%")
+                                if (reg.skillPtTrainingEffect > 0) add("スキルPt効果: +${reg.skillPtTrainingEffect}%")
+                                if (reg.friendBonus > 0) add("友情ボーナス: +${reg.friendBonus}%")
+                                if (reg.hintCount > 0) add("ヒント獲得数: +${reg.hintCount}")
+                                if (reg.addMember > 0) add("サポカ追加配置: +${reg.addMember}")
+                                if (reg.targetAll) add("全トレーニング対象")
+                                if (reg.targetStatusLimitOver > 0) add("上限突破: +${reg.targetStatusLimitOver}")
+                                if (reg.hintSkill.isNotEmpty()) add("スキルヒント: ${reg.hintSkill}")
+                            }
+                            Text("試食効果：${effects.joinToString(", ")}")
+                        }
+                    }
                 }
                 val targetAiScore = aiScore.getOrNull(index)
                 if (aiSelection == action || targetAiScore != null) {
@@ -346,5 +393,20 @@ private fun BCInfo(action: Action) {
         Text(param.member.joinToString(", ") {
             "${it.charaName} ${it.memberRankString} ${it.dreamGauge}/3"
         })
+    }
+}
+
+@Composable
+private fun RamenInfo(action: Action) {
+    val param = action.candidates.firstOrNull { it.first.success }
+        ?.first?.scenarioActionParam as? RamenActionParam ?: return
+    Div {
+        val list = buildList {
+            if (param.noodleGauge > 0) add("麺ゲージ: +${param.noodleGauge}")
+            if (param.soupGauge > 0) add("スープゲージ: +${param.soupGauge}")
+            if (param.toppingGauge > 0) add("トッピングゲージ: +${param.toppingGauge}")
+            if (param.hiddenTaste > 0) add("隠し味: +${param.hiddenTaste}")
+        }
+        Text(list.joinToString(", "))
     }
 }

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/simulation/SimulationPage.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/simulation/SimulationPage.kt
@@ -51,6 +51,7 @@ fun SimulationPage(state: State) {
                 Scenario.MUJINTO -> MujintoActionSelector.Option()
                 Scenario.ONSEN -> OnsenActionSelector2.Option()
                 Scenario.BC -> BCActionSelector.Option()
+                Scenario.RAMEN -> null
                 else -> null
             }
         )

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/simulation/SimulationStateBlock.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/simulation/SimulationStateBlock.kt
@@ -182,6 +182,9 @@ fun SimulationStateBlock(state: SimulationState) {
         state.bcStatus?.let {
             BCStateBlock(it)
         }
+        state.ramenStatus?.let {
+            RamenStateBlock(it)
+        }
         HideBlock("サポートカード") {
             state.support.forEach {
                 MemberState(it)


### PR DESCRIPTION
This PR implements the manual simulation UI for the Ramen scenario ("らっしゃい！トレセン軒！") inside the web module. It introduces a comprehensive state block showing excitement points, ranks, ingredients, tips, tasting status, and RMJ bonuses, and enhances selection blocks to present region options and trial/tasting details. Additionally, it resolves an out-of-bounds bug on JS/Wasm targets during training tip shuffling and a potential crash when initializing the simulator with empty support cards.

---
*PR created automatically by Jules for task [11316672932278933331](https://jules.google.com/task/11316672932278933331) started by @mee1080*