### PR TITLE
Add Ramen Tasting Hidden Tips Substitution support

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenCalculator.kt
@@ -114,20 +114,35 @@ object RamenCalculator : ScenarioCalculator {
     ): Array<Action> {
         val status = state.ramenStatus ?: return emptyArray()
         if (state.turn >= 73) return emptyArray()
-        val availableTasting = status.selectedRegions.filter { region ->
-            val tips = status.tips
+        val tips = status.tips
 
-            fun canAfford(type: RamenTipType, amount: Int): Int {
-                return (amount - (tips[type] ?: 0)).coerceAtLeast(0)
-            }
-
-            val neededHidden = canAfford(RamenTipType.NOODLE, region.noodle) +
-                    canAfford(RamenTipType.SOUP, region.soup) +
-                    canAfford(RamenTipType.TOPPING, region.topping)
-
-            status.hiddenTips >= neededHidden
+        fun canAfford(type: RamenTipType, amount: Int): Int {
+            return (amount - (tips[type] ?: 0)).coerceAtLeast(0)
         }
-        return availableTasting.map { RamenTasting(it) }.toTypedArray()
+
+        val actions = mutableListOf<Action>()
+        for (region in status.selectedRegions) {
+            for (cn in 0..region.noodle) {
+                for (cs in 0..region.soup) {
+                    for (ct in 0..region.topping) {
+                        if (cn + cs + ct > 2) continue
+                        val neededHidden = cn + cs + ct +
+                                canAfford(RamenTipType.NOODLE, region.noodle - cn) +
+                                canAfford(RamenTipType.SOUP, region.soup - cs) +
+                                canAfford(RamenTipType.TOPPING, region.topping - ct)
+                        if (status.hiddenTips >= neededHidden) {
+                            val changeHiddenList = buildList {
+                                repeat(cn) { add(RamenTipType.NOODLE) }
+                                repeat(cs) { add(RamenTipType.SOUP) }
+                                repeat(ct) { add(RamenTipType.TOPPING) }
+                            }
+                            actions.add(RamenTasting(region, changeHiddenList))
+                        }
+                    }
+                }
+            }
+        }
+        return actions.toTypedArray()
     }
 
     override fun modifyShuffledMember(
@@ -203,7 +218,7 @@ object RamenCalculator : ScenarioCalculator {
         val ramenStatus = state.ramenStatus ?: return state
         val region = result.region
         var newState = state.updateRamenStatus {
-            activateTasting(region)
+            activateTasting(region, result.changeHiddenTips)
         }
 
         // relationGauge: 絆上昇

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenStatus.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenStatus.kt
@@ -137,17 +137,23 @@ data class RamenStatus(
         return copy(hiddenTips = min(4, hiddenTips + amount))
     }
 
-    fun activateTasting(region: RamenRegion): RamenStatus {
+    fun activateTasting(region: RamenRegion, changeHiddenTips: List<RamenTipType> = emptyList()): RamenStatus {
         var state = this
-        repeat(region.noodle) {
-            state = state.removeTipOrHidden(RamenTipType.NOODLE)
+        val changeCounts = changeHiddenTips.groupingBy { it }.eachCount()
+
+        fun processType(type: RamenTipType, required: Int) {
+            val changeCount = changeCounts[type] ?: 0
+            state = state.addHiddenTips(-changeCount)
+            val normalRequired = required - changeCount
+            repeat(normalRequired) {
+                state = state.removeTipOrHidden(type)
+            }
         }
-        repeat(region.soup) {
-            state = state.removeTipOrHidden(RamenTipType.SOUP)
-        }
-        repeat(region.topping) {
-            state = state.removeTipOrHidden(RamenTipType.TOPPING)
-        }
+
+        processType(RamenTipType.NOODLE, region.noodle)
+        processType(RamenTipType.SOUP, region.soup)
+        processType(RamenTipType.TOPPING, region.topping)
+
         val gainPt = ramenGainExcitePt[period]
         val tastingCount = min(5, excitementPt / gainPt / 10)
         return state.copy(

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/Action.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/Action.kt
@@ -651,12 +651,20 @@ data class RamenSelectRegion(
 
 data class RamenTastingResult(
     val region: RamenRegion,
+    val changeHiddenTips: List<RamenTipType> = emptyList(),
 ) : RamenActionResult
 
 data class RamenTasting(
     val region: RamenRegion,
+    val changeHiddenTips: List<RamenTipType> = emptyList(),
 ) : SingleAction {
     override val name = "試食会: ${region.displayName}"
     override val turnChange = false
-    override val result = RamenTastingResult(region)
+    override val result = RamenTastingResult(region, changeHiddenTips)
+    override fun infoToString(): String {
+        if (changeHiddenTips.isEmpty()) return ""
+        val counts = changeHiddenTips.groupingBy { it }.eachCount()
+        val parts = counts.map { "${it.key.displayName}${it.value}変更" }
+        return "(${parts.joinToString(", ")})"
+    }
 }

--- a/core/src/commonTest/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenHiddenTipsTest.kt
+++ b/core/src/commonTest/kotlin/io/github/mee1080/umasim/scenario/ramen/RamenHiddenTipsTest.kt
@@ -1,0 +1,63 @@
+package io.github.mee1080.umasim.scenario.ramen
+
+import io.github.mee1080.umasim.simulation2.RamenTasting
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RamenHiddenTipsTest : RamenCalculatorTest(
+    chara = Triple("[初うらら♪さくさくら]ハルウララ", 5, 5),
+    supportCardList = listOf(
+        "[世界を変える眼差し]アーモンドアイ" to 4,
+        "[心覚えし、京の華]エアグルーヴ" to 4,
+        "[アルストロメリアの夢]ヴィブロス" to 4,
+        "[Devilish Whispers]スティルインラブ" to 4,
+        "[The frontier]ジャングルポケット" to 4,
+        "[永久の誓い、永久の輝き]サトノダイヤモンド" to 4,
+    )
+) {
+    @Test
+    fun testPredictScenarioAction() {
+        var customState = state.copy(
+            scenarioStatus = RamenStatus(
+                selectedRegions = listOf(RamenRegion.SAPPORO),
+                tips = mapOf(
+                    RamenTipType.NOODLE to 2,
+                    RamenTipType.SOUP to 2,
+                    RamenTipType.TOPPING to 1
+                ),
+                hiddenTips = 0
+            )
+        )
+
+        // 1. With 0 hiddenTips and full normal tips
+        var actions = RamenCalculator.predictScenarioAction(customState, false).filterIsInstance<RamenTasting>()
+        println("Actions for 0 hidden tips: ${actions.map { it.toShortString() }}")
+        assertEquals(1, actions.size)
+        assertTrue(actions[0].changeHiddenTips.isEmpty())
+
+        // 2. With 1 hiddenTips and full normal tips
+        customState = customState.updateRamenStatus {
+            copy(hiddenTips = 1)
+        }
+        actions = RamenCalculator.predictScenarioAction(customState, false).filterIsInstance<RamenTasting>()
+        println("Actions for 1 hidden tip: ${actions.map { it.toShortString() }}")
+        assertEquals(4, actions.size)
+        val expectedChanges = listOf(
+            emptyList(),
+            listOf(RamenTipType.NOODLE),
+            listOf(RamenTipType.SOUP),
+            listOf(RamenTipType.TOPPING)
+        )
+        val actualChanges = actions.map { it.changeHiddenTips }
+        assertEquals(expectedChanges.toSet(), actualChanges.toSet())
+
+        // 3. Test activateTasting with changeHiddenTips
+        val ramenStatus = customState.ramenStatus!!
+        val nextRamenStatus = ramenStatus.activateTasting(RamenRegion.SAPPORO, listOf(RamenTipType.NOODLE))
+        assertEquals(1, nextRamenStatus.tips[RamenTipType.NOODLE])
+        assertEquals(0, nextRamenStatus.tips[RamenTipType.SOUP])
+        assertEquals(0, nextRamenStatus.tips[RamenTipType.TOPPING])
+        assertEquals(0, nextRamenStatus.hiddenTips)
+    }
+}


### PR DESCRIPTION
This PR adds the ability to replace normal tips with hidden tips (up to 2) in the Ramen Tasting action. It supports generating all valid combinations in action prediction, and correctly handles resource consumption during tasting activation.

---
*PR created automatically by Jules for task [15309500529297706756](https://jules.google.com/task/15309500529297706756) started by @mee1080*