### PR TITLE
Update RamenActionSelector Logic and Options

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/ai/RamenActionSelector.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/ai/RamenActionSelector.kt
@@ -1,5 +1,8 @@
 package io.github.mee1080.umasim.ai
 
+import io.github.mee1080.umasim.scenario.ramen.RamenCalculator
+import io.github.mee1080.umasim.scenario.ramen.RamenRegion
+import io.github.mee1080.umasim.scenario.ramen.RamenTipType
 import io.github.mee1080.umasim.simulation2.*
 import kotlinx.serialization.Serializable
 
@@ -26,6 +29,7 @@ open class RamenActionSelector(
             add(base)
             add(
                 base.copy(
+                    speedOverride = 50,
                     wisdom = 90,
                     hp = 750,
                     hpKeep = 700,
@@ -58,6 +62,7 @@ open class RamenActionSelector(
     @Serializable
     data class Option(
         val status: Int = 100,
+        val speedOverride: Int? = null,
         override val wisdom: Int = 80,
         override val skillPt: Int = 1000,
         override val hp: Int = 400,
@@ -67,41 +72,41 @@ open class RamenActionSelector(
         override val hpKeep: Int = 900,
         override val risk: Int = 300,
 
-        val regionPriority: List<String> = listOf(
+        val regionPriority: List<RamenRegion> = listOf(
             // Junior (Period 0)
-            "SAPPORO",
-            "HAKODATE",
-            "TOKYO",
-            "FUKUSHIMA",
-            "NIIGATA",
+            RamenRegion.SAPPORO,
+            RamenRegion.HAKODATE,
+            RamenRegion.TOKYO,
+            RamenRegion.FUKUSHIMA,
+            RamenRegion.NIIGATA,
             // Classic (Period 1)
-            "KOKURA",
-            "HANSHIN",
-            "KYOTO",
-            "CHUKYO",
-            "NAKAYAMA",
+            RamenRegion.KOKURA,
+            RamenRegion.HANSHIN,
+            RamenRegion.KYOTO,
+            RamenRegion.CHUKYO,
+            RamenRegion.NAKAYAMA,
             // Senior (Period 2)
-            "SAPPORO2",
-            "HAKODATE2",
-            "KYOTO2",
-            "HANSHIN2",
-            "KOKURA2",
-            "TOKYO2",
-            "NIIGATA2",
-            "FUKUSHIMA2",
-            "CHUKYO2",
-            "NAKAYAMA2",
+            RamenRegion.SAPPORO2,
+            RamenRegion.HAKODATE2,
+            RamenRegion.KYOTO2,
+            RamenRegion.HANSHIN2,
+            RamenRegion.KOKURA2,
+            RamenRegion.TOKYO2,
+            RamenRegion.NIIGATA2,
+            RamenRegion.FUKUSHIMA2,
+            RamenRegion.CHUKYO2,
+            RamenRegion.NAKAYAMA2,
             // Finals (Period 3)
-            "FINALS1",
-            "FINALS2",
-            "FINALS3"
+            RamenRegion.FINALS1,
+            RamenRegion.FINALS2,
+            RamenRegion.FINALS3
         ),
         val tastingScoreThreshold: Double = 15.0,
         val tastingSupportCountThreshold: Int = 2,
         val tastingFriendshipCountThreshold: Int = 1,
         val gaugeScore: Double = 10.0,
     ) : SerializableActionSelectorGenerator, BaseOption {
-        override val speed get() = status
+        override val speed get() = speedOverride ?: status
         override val stamina get() = status
         override val power get() = status
         override val guts get() = status
@@ -156,7 +161,9 @@ open class RamenActionSelector(
         (selected.first as? Race)?.let { race ->
             if (state.status.hp + race.result.status.hp <= 50) {
                 context.selectionWithScore.firstOrNull { it.first is Sleep }?.let {
-                    selected = it
+                    if (it.second > Double.MIN_VALUE) {
+                        selected = it
+                    }
                 }
             }
         }
@@ -166,21 +173,106 @@ open class RamenActionSelector(
             val supportOuting = context.selectionWithScore.firstOrNull {
                 (it.first as? Outing)?.support != null
             }
-            if (supportOuting != null) {
+            if (supportOuting != null && supportOuting.second > Double.MIN_VALUE) {
                 selected = supportOuting
             }
         }
         return selected
     }
 
+    private fun isFriendOutingBlocked(state: SimulationState, action: Outing): Boolean {
+        if (action.support == null) return false
+        val turn = state.turn
+        if (turn <= 24) return true // ジュニアでは友人お出かけは行わない
+        if (turn in 25..48) {
+            // クラシックでは友人お出かけは3回まで
+            val count = state.member.filter { it.outingType }.sumOf {
+                maxOf(0, (it.supportState?.outingStep ?: 0) - 2)
+            }
+            if (count >= 3) return true
+        }
+        return false
+    }
+
+    private fun isSleepOrOutingBlockedByHp(state: SimulationState, action: Action): Boolean {
+        if (state.status.hp >= 70) {
+            if (action is Sleep || action is Outing) {
+                return true
+            }
+        }
+        return false
+    }
+
     override suspend fun calcScenarioActionScore(
         context: Context,
         action: Action
     ): Double? {
+        val state = context.state
+        if (action is Outing && isFriendOutingBlocked(state, action)) {
+            return Double.MIN_VALUE
+        }
+        if (isSleepOrOutingBlockedByHp(state, action)) {
+            return Double.MIN_VALUE
+        }
+
+        val turn = state.turn
+        val ramenStatus = state.ramenStatus
+        if (ramenStatus != null) {
+            val totalTips = ramenStatus.tips.values.sum()
+            val hiddenTips = ramenStatus.hiddenTips
+
+            val isBeforeCamp = turn in 33..36 || turn in 57..60
+            val isClassicEnd = turn in 45..48
+
+            // ジュニアでは隠し味を使わない
+            if (turn <= 24 && action is RamenTasting && action.changeHiddenTips.isNotEmpty()) {
+                return Double.MIN_VALUE
+            }
+
+            if (isBeforeCamp || isClassicEnd) {
+                if (action is RamenTasting) {
+                    val usedHidden = action.changeHiddenTips.size
+                    val remainingHidden = hiddenTips - usedHidden
+
+                    if (hiddenTips >= 3) {
+                        if (remainingHidden > 2) {
+                            return Double.MIN_VALUE
+                        }
+                    } else {
+                        if (usedHidden > 0) {
+                            return Double.MIN_VALUE
+                        }
+                    }
+
+                    if (isBeforeCamp) {
+                        val spentNormalTips = action.region.noodle + action.region.soup + action.region.topping - usedHidden
+                        val remainingNormalTips = totalTips - spentNormalTips
+                        if (remainingNormalTips < 7) {
+                            if (hiddenTips >= 3 && remainingHidden <= 2) {
+                                // 隠し味を減らすことを優先し許容する
+                            } else {
+                                return Double.MIN_VALUE
+                            }
+                        }
+                    }
+                } else {
+                    if (hiddenTips >= 3) {
+                        val tastings = RamenCalculator.predictScenarioAction(state, false)
+                        val hasValidTasting = tastings.any { act ->
+                            act is RamenTasting && (hiddenTips - act.changeHiddenTips.size <= 2)
+                        }
+                        if (hasValidTasting) {
+                            return Double.MIN_VALUE
+                        }
+                    }
+                }
+            }
+        }
+
         if (action is RamenSelectRegion) {
             val option = context.option
             val region = action.region
-            val index = option.regionPriority.indexOf(region.name)
+            val index = option.regionPriority.indexOf(region)
             return if (index >= 0) {
                 10000.0 - index
             } else {
@@ -246,10 +338,28 @@ open class RamenActionSelector(
 
         return if (shouldTaste) {
             val hiddenTipPenalty = action.changeHiddenTips.size * 10.0
-            val regionPriorityIndex = option.regionPriority.indexOf(region.name)
+            val regionPriorityIndex = option.regionPriority.indexOf(region)
             val priorityBonus = if (regionPriorityIndex >= 0) (100 - regionPriorityIndex) * 0.1 else 0.0
 
-            reasonScore - hiddenTipPenalty + priorityBonus
+            var baseScore = reasonScore - hiddenTipPenalty + priorityBonus
+
+            // 試食会で隠し味は残り2個までは優先的に使う
+            val remainingHidden = (state.ramenStatus?.hiddenTips ?: 0) - action.changeHiddenTips.size
+            if (action.changeHiddenTips.isNotEmpty() && remainingHidden >= 2) {
+                baseScore += 50.0
+            }
+
+            // 隠し味を使う場合、残りが少なくなるコツを変換する
+            if (action.changeHiddenTips.isNotEmpty()) {
+                val sumRemainingConverted = action.changeHiddenTips.distinct().sumOf { type ->
+                    val totalTips = state.ramenStatus?.tips?.get(type) ?: 0
+                    val convertCount = action.changeHiddenTips.count { it == type }
+                    totalTips - convertCount
+                }
+                baseScore += (10.0 - sumRemainingConverted * 1.0)
+            }
+
+            baseScore
         } else {
             Double.MIN_VALUE
         }

--- a/core/src/commonTest/kotlin/io/github/mee1080/umasim/ai/RamenActionSelectorTest.kt
+++ b/core/src/commonTest/kotlin/io/github/mee1080/umasim/ai/RamenActionSelectorTest.kt
@@ -4,8 +4,7 @@ import io.github.mee1080.umasim.data.Status
 import io.github.mee1080.umasim.data.StatusType
 import io.github.mee1080.umasim.data.Store
 import io.github.mee1080.umasim.scenario.Scenario
-import io.github.mee1080.umasim.scenario.ramen.RamenRegion
-import io.github.mee1080.umasim.scenario.ramen.RamenStatus
+import io.github.mee1080.umasim.scenario.ramen.*
 import io.github.mee1080.umasim.simulation2.*
 import io.github.mee1080.umasim.test.loadTestStore
 import kotlinx.coroutines.test.runTest
@@ -111,5 +110,230 @@ class RamenActionSelectorTest {
         val score3 = selector.calcScenarioActionScore(context3, tastingAction)
         assertNotNull(score3)
         assertTrue(score3 > 1000.0)
+    }
+
+    @Test
+    fun testJuniorFriendOutingBlocked() = runTest {
+        val selector = TestRamenActionSelector()
+        val baseState = Simulator(
+            scenario = Scenario.RAMEN,
+            chara = Store.getChara("[初うらら♪さくさくら]ハルウララ", 5, 5),
+            supportCardList = Store.getSupportByName("[一杯のノスタルジア]駿川たづな" to 4)
+        ).initialState
+        val state = baseState.copy(
+            scenarioStatus = RamenStatus(),
+            turn = 10,
+            status = baseState.status.copy(hp = 50) // Ensure HP is low so not blocked by HP check
+        )
+
+        val friendCard = state.member.first { it.outingType }
+        val friendOuting = Outing(friendCard, listOf(StatusActionResult(Status()) to 1))
+        val context = selector.getContext(state)
+
+        val score = selector.calcScenarioActionScore(context, friendOuting)
+        assertEquals(Double.MIN_VALUE, score)
+    }
+
+    @Test
+    fun testClassicFriendOutingsLimit() = runTest {
+        val selector = TestRamenActionSelector()
+
+        // Classic period, turn 30
+        val baseState = Simulator(
+            scenario = Scenario.RAMEN,
+            chara = Store.getChara("[初うらら♪さくさくら]ハルウララ", 5, 5),
+            supportCardList = Store.getSupportByName("[一杯のノスタルジア]駿川たづな" to 4)
+        ).initialState
+        val state = baseState.copy(
+            scenarioStatus = RamenStatus(),
+            turn = 30,
+            status = baseState.status.copy(hp = 50) // Ensure HP is low so not blocked by HP check
+        )
+
+        val friendCardIndex = state.member.indexOfFirst { it.outingType }
+        val friendCard = state.member[friendCardIndex]
+        val friendOuting = Outing(friendCard, listOf(StatusActionResult(Status()) to 1))
+
+        // Case 1: 0 previous outings (outingStep = 2)
+        val memberWithStep2 = state.member.mapIndexed { index, member ->
+            if (index == friendCardIndex) {
+                member.copy(supportState = member.supportState?.copy(outingStep = 2))
+            } else member
+        }
+        var context = selector.getContext(state.copy(member = memberWithStep2))
+        var score = selector.calcScenarioActionScore(context, friendOuting)
+        assertTrue(score != Double.MIN_VALUE)
+
+        // Case 2: 3 previous outings (outingStep = 5)
+        val memberWithStep5 = state.member.mapIndexed { index, member ->
+            if (index == friendCardIndex) {
+                member.copy(supportState = member.supportState?.copy(outingStep = 5))
+            } else member
+        }
+        context = selector.getContext(state.copy(member = memberWithStep5))
+        score = selector.calcScenarioActionScore(context, friendOuting)
+        assertEquals(Double.MIN_VALUE, score)
+    }
+
+    @Test
+    fun testHighHpSleepAndOutingBlocked() = runTest {
+        val selector = TestRamenActionSelector()
+
+        // HP is 75 (>= 70)
+        val state = sampleState.copy(status = sampleState.status.copy(hp = 75))
+        val context = selector.getContext(state)
+
+        val sleepAction = Sleep(listOf(StatusActionResult(Status()) to 1))
+        val outingAction = Outing(null, listOf(StatusActionResult(Status()) to 1))
+
+        assertEquals(Double.MIN_VALUE, selector.calcScenarioActionScore(context, sleepAction))
+        assertEquals(Double.MIN_VALUE, selector.calcScenarioActionScore(context, outingAction))
+
+        // HP is 65 (< 70) -> Should NOT be blocked
+        val stateLowHp = sampleState.copy(status = sampleState.status.copy(hp = 65))
+        val contextLowHp = selector.getContext(stateLowHp)
+        assertTrue(selector.calcScenarioActionScore(contextLowHp, sleepAction) != Double.MIN_VALUE)
+    }
+
+    @Test
+    fun testClassicPeriodSpeedPriority() {
+        val selector = RamenActionSelector()
+
+        val contextJunior = selector.getContext(sampleState.copy(turn = 10))
+        val contextClassic = selector.getContext(sampleState.copy(turn = 30))
+
+        assertEquals(100, contextJunior.option.speed)
+        assertEquals(50, contextClassic.option.speed)
+    }
+
+    @Test
+    fun testJuniorPeriodTastingHiddenTipsBlocked() = runTest {
+        val selector = TestRamenActionSelector()
+
+        // Junior period, turn 10
+        val state = sampleState.copy(
+            turn = 10,
+            scenarioStatus = RamenStatus(
+                selectedRegions = listOf(RamenRegion.SAPPORO)
+            )
+        )
+        val context = selector.getContext(state)
+
+        val tastingWithHidden = RamenTasting(RamenRegion.SAPPORO, listOf(RamenTipType.NOODLE))
+        assertEquals(Double.MIN_VALUE, selector.calcScenarioActionScore(context, tastingWithHidden))
+    }
+
+    @Test
+    fun testCampAndClassicEndAdjustments() = runTest {
+        val selector = TestRamenActionSelector()
+
+        // Turn 35 (Before Camp)
+        // Target: 7 total tips, 2 hidden tips. (3 or more hidden tips is NOT allowed)
+        // Case 1: hiddenTips is 3 (>= 3). Only tastings reducing hiddenTips to <= 2 are allowed.
+        val stateHighHidden = sampleState.copy(
+            turn = 35,
+            scenarioStatus = RamenStatus(
+                selectedRegions = listOf(RamenRegion.SAPPORO),
+                hiddenTips = 3,
+                tips = mapOf(RamenTipType.NOODLE to 5, RamenTipType.SOUP to 5, RamenTipType.TOPPING to 5)
+            )
+        )
+        val contextHighHidden = selector.getContext(stateHighHidden)
+
+        // Tasting reducing hiddenTips to 2 (used 1) -> Allowed
+        val tastingReducing = RamenTasting(RamenRegion.SAPPORO, listOf(RamenTipType.NOODLE))
+        val scoreReducing = selector.calcScenarioActionScore(contextHighHidden, tastingReducing)
+        // Not Double.MIN_VALUE (and should taste can be false, but it's not strictly blocked prior to testing analysis if there's valid training)
+        assertTrue(scoreReducing != Double.MIN_VALUE)
+
+        // Tasting not reducing (used 0) -> Blocked
+        val tastingNotReducing = RamenTasting(RamenRegion.SAPPORO, emptyList())
+        assertEquals(Double.MIN_VALUE, selector.calcScenarioActionScore(contextHighHidden, tastingNotReducing))
+
+        // Non-tasting action -> Blocked if a valid tasting exists
+        val sleepAction = Sleep(listOf(StatusActionResult(Status()) to 1))
+        assertEquals(Double.MIN_VALUE, selector.calcScenarioActionScore(contextHighHidden, sleepAction))
+    }
+
+    @Test
+    fun testPriorityUsingHiddenTips() = runTest {
+        val selector = TestRamenActionSelector()
+
+        // Classic period, turn 30. Set hidden tips to 4.
+        val state = sampleState.copy(
+            turn = 30,
+            scenarioStatus = RamenStatus(
+                selectedRegions = listOf(RamenRegion.SAPPORO),
+                hiddenTips = 4,
+                tips = mapOf(RamenTipType.NOODLE to 0, RamenTipType.SOUP to 2, RamenTipType.TOPPING to 2)
+            )
+        )
+        val context = selector.getContext(state)
+        // Add a training action with high score so tasting can trigger
+        val trainingSpeed = Training(
+            type = StatusType.SPEED,
+            failureRate = 0,
+            level = 1,
+            member = emptyList(),
+            candidates = emptyList(),
+            baseStatus = Status(),
+            friendTraining = false
+        )
+        context.add(trainingSpeed, 20.0)
+
+        // Case A: convert 1, remaining = 3 (>= 2)
+        val tastingRemaining3 = RamenTasting(RamenRegion.SAPPORO, listOf(RamenTipType.NOODLE))
+        // Case B: convert 3, remaining = 1 (< 2)
+        val tastingRemaining1 = RamenTasting(RamenRegion.SAPPORO, listOf(RamenTipType.NOODLE, RamenTipType.SOUP, RamenTipType.TOPPING))
+
+        val score3 = selector.calcScenarioActionScore(context, tastingRemaining3)
+        val score1 = selector.calcScenarioActionScore(context, tastingRemaining1)
+
+        assertNotNull(score3)
+        assertNotNull(score1)
+        // score3 should be higher due to the +50.0 priority bonus for remaining >= 2
+        assertTrue(score3 > score1)
+    }
+
+    @Test
+    fun testTieBreakingMinimizingRemainingConverted() = runTest {
+        val selector = TestRamenActionSelector()
+
+        // Noodle has 3 tips, Soup has 1 tip.
+        // We use 1 hidden tip to convert either Noodle or Soup.
+        // Converting Soup leaves 1 - 1 = 0 Soup tips (remaining minimized).
+        // Converting Noodle leaves 3 - 1 = 2 Noodle tips.
+        val state = sampleState.copy(
+            turn = 30,
+            scenarioStatus = RamenStatus(
+                selectedRegions = listOf(RamenRegion.SAPPORO),
+                hiddenTips = 2,
+                tips = mapOf(RamenTipType.NOODLE to 3, RamenTipType.SOUP to 1, RamenTipType.TOPPING to 5)
+            )
+        )
+        val context = selector.getContext(state)
+        val trainingSpeed = Training(
+            type = StatusType.SPEED,
+            failureRate = 0,
+            level = 1,
+            member = emptyList(),
+            candidates = emptyList(),
+            baseStatus = Status(),
+            friendTraining = false
+        )
+        context.add(trainingSpeed, 20.0)
+
+        // Tasting A: converts Soup (remaining Soup tips after conversion = 0)
+        val tastingConvertSoup = RamenTasting(RamenRegion.SAPPORO, listOf(RamenTipType.SOUP))
+        // Tasting B: converts Noodle (remaining Noodle tips after conversion = 2)
+        val tastingConvertNoodle = RamenTasting(RamenRegion.SAPPORO, listOf(RamenTipType.NOODLE))
+
+        val scoreConvertSoup = selector.calcScenarioActionScore(context, tastingConvertSoup)
+        val scoreConvertNoodle = selector.calcScenarioActionScore(context, tastingConvertNoodle)
+
+        assertNotNull(scoreConvertSoup)
+        assertNotNull(scoreConvertNoodle)
+        // scoreConvertSoup should be higher because remainingConverted tips is 0, which is smaller than 2.
+        assertTrue(scoreConvertSoup > scoreConvertNoodle)
     }
 }


### PR DESCRIPTION
Updated RamenActionSelector with the following fixes:
- Junior period blocks friend outings.
- Classic period restricts friend outings to a maximum of 3.
- Sleep and Outing are blocked when HP is >= 70.
- Classic period speed priority is reduced to 50.
- regionPriority was updated from List<String> to List<RamenRegion> for enum safety.
- Junior period blocks using hidden tips.
- Adjusted before summer camps (turns 33-36, 57-60) and Classic period end (turns 45-48) to target 7 total tips and 2 hidden tips.
- Prioritized using hidden tips if >= 2 remain after usage.
- Handled tie-breaking when using hidden tips to minimize remaining converted tips.
- Expanded the unit test suite to fully cover all new logic and constraints.

---
*PR created automatically by Jules for task [1407433396550577878](https://jules.google.com/task/1407433396550577878) started by @mee1080*