### PR TITLE
Implement event training effect bonus for training limit

### DIFF
--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/Calculator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/Calculator.kt
@@ -56,6 +56,7 @@ object Calculator {
         val totalTrainingLevel: Int,
         val isLevelUpTurn: Boolean,
         val scenarioStatus: ScenarioStatus?,
+        val eventTrainingEffect: Int = 0,
     ) {
         val liveStatus get() = scenarioStatus as? TrainingLiveStatus
         val gmStatus get() = scenarioStatus as? GmStatus
@@ -197,7 +198,7 @@ object Calculator {
         val trainingBonus =
             1 + (support.sumOf {
                 it.card.trainingFactor(baseCondition.applyMember(it))
-            } + (bonus?.trainingBonus ?: 0)) / 100.0
+            } + info.eventTrainingEffect + (bonus?.trainingBonus ?: 0)) / 100.0
         val count = 1 + info.member.size * 0.05
         val scenarioFactor = bonus?.additionalFactor ?: 1.0
         if (DEBUG) println("$targetType base=$baseStatus baseBonus=$base chara=$charaBonus friend=$friend motivation=$motivationBonus training=$trainingBonus count=$count scenario=$scenarioFactor")

--- a/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/ExpectedCalculator.kt
+++ b/core/src/commonMain/kotlin/io/github/mee1080/umasim/simulation2/ExpectedCalculator.kt
@@ -48,6 +48,7 @@ class ExpectedCalculator(
         totalTrainingLevel: Int,
         isLevelUpTurn: Boolean,
         val scenarioStatus: ScenarioStatus?,
+        val eventTrainingEffect: Int = 0,
     ) {
 
         val liveStatus get() = scenarioStatus as? TrainingLiveStatus
@@ -68,6 +69,7 @@ class ExpectedCalculator(
             totalTrainingLevel = totalTrainingLevel,
             isLevelUpTurn = isLevelUpTurn,
             scenarioStatus = scenarioStatus,
+            eventTrainingEffect = eventTrainingEffect,
         )
 
         fun toCalcInfo(type: StatusType, factors: List<Wrapper>, count: Int): Calculator.CalcInfo {

--- a/core/src/commonTest/kotlin/io/github/mee1080/umasim/simulation2/CalculatorTest.kt
+++ b/core/src/commonTest/kotlin/io/github/mee1080/umasim/simulation2/CalculatorTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 mee1080
+ *
+ * This file is part of umasim.
+ *
+ * umasim is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * umasim is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with umasim.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package io.github.mee1080.umasim.simulation2
+
+import io.github.mee1080.umasim.scenario.Scenario
+import io.github.mee1080.umasim.data.StatusType
+import io.github.mee1080.umasim.data.Store
+import io.github.mee1080.umasim.test.loadTestStore
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CalculatorTest {
+
+    @BeforeTest
+    fun setUp() {
+        loadTestStore()
+    }
+
+    @Test
+    fun testEventTrainingEffect() {
+        val baseState = Simulator(
+            scenario = Scenario.URA,
+            chara = Store.getChara("[初うらら♪さくさくら]ハルウララ", 5, 5),
+            supportCardList = Store.getSupportByName("[一杯のノスタルジア]駿川たづな" to 4)
+        ).initialState
+
+        val infoDefault = baseState.baseCalcInfo.copy(
+            training = baseState.training[0].current, // SPEED training
+            eventTrainingEffect = 0
+        )
+        val resultDefault = Calculator.calcTrainingSuccessStatus(infoDefault)
+
+        val infoWithEffect = infoDefault.copy(
+            eventTrainingEffect = 20
+        )
+        val resultWithEffect = Calculator.calcTrainingSuccessStatus(infoWithEffect)
+
+        // Check that training with eventTrainingEffect = 20 has strictly higher speed gain than default
+        println("Default Speed Gain: ${resultDefault.speed}")
+        println("With Effect Speed Gain: ${resultWithEffect.speed}")
+        assertTrue(resultWithEffect.speed > resultDefault.speed, "Speed gain should be higher when eventTrainingEffect is 20")
+    }
+}

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
@@ -181,6 +181,11 @@ fun TrainingInfo(model: ViewModel, state: State) {
                 model.updateTeamJoinCount(it.toInt())
             }
         }
+        DivFlexCenter {
+            MdCheckbox("トレーニング制限", state.eventTrainingLimit) {
+                onChange { model.update { copy(eventTrainingLimit = it) } }
+            }
+        }
         if (state.scenario == Scenario.CLIMAX) {
             DivFlexCenter {
                 Text("メガホン：")

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
@@ -60,6 +60,7 @@ data class State(
     val trainingLevel: Int = 1,
     val motivation: Int = 2,
     val isLevelUpTurn: Boolean = false,
+    val eventTrainingLimit: Boolean = false,
     val fanCount: Int = 0,
     val hp: Int = 50,
     val maxHp: Int = 100,

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
@@ -349,6 +349,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
             state.totalTrainingLevel,
             state.isLevelUpTurn,
             scenarioStatus,
+            if (state.eventTrainingLimit) 20 else 0,
         ).setTeamMember(state.teamJoinCount)
         val scenarioBonus = state.scenario.calculator.getScenarioCalcBonus(trainingCalcInfo)
         val trainingResult = Calculator.calcTrainingSuccessStatusSeparated(trainingCalcInfo, scenarioBonus)
@@ -401,6 +402,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
                     state.totalTrainingLevel,
                     state.isLevelUpTurn,
                     scenarioStatus,
+                    if (state.eventTrainingLimit) 20 else 0,
                 ).setTeamMember(state.teamJoinCount)
             )
             target.name to trainingResult.first.first + trainingResult.second - notJoinResult.first.first - notJoinResult.second
@@ -470,6 +472,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
                 state.totalTrainingLevel,
                 state.isLevelUpTurn,
                 scenarioStatus,
+                if (state.eventTrainingLimit) 20 else 0,
             ),
             state.teamJoinCount,
             // TODO ScenarioCalculator使用
@@ -561,6 +564,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
                 state.totalTrainingLevel,
                 state.isLevelUpTurn,
                 state.scenarioStatus,
+                if (state.eventTrainingLimit) 20 else 0,
             )
             val typeRate = state.expectedState.targetTypes.associateWith { 0.0 }.toMutableMap()
             val expected = ExpectedCalculator(
@@ -842,6 +846,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
                 state.totalTrainingLevel,
                 state.isLevelUpTurn,
                 uafStatus,
+                if (state.eventTrainingLimit) 20 else 0,
             )
             val result = UafAthleticsLevelCalculator.calc(trainingCalcInfo, state.uafState.athleticsLevelUpBonus)
             var expected = 0.0
@@ -916,6 +921,7 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
                 state.totalTrainingLevel,
                 state.isLevelUpTurn,
                 ramenStatus,
+                if (state.eventTrainingLimit) 20 else 0,
             ).setTeamMember(state.teamJoinCount)
 
             val noTastingStatus = ramenStatus.copy(activeTastingRegion = null)


### PR DESCRIPTION
Implement eventTrainingEffect in Calculator, add 'トレーニング制限' checkbox in TrainingInfo.kt, and verify calculations and UI via Playwright screenshot.

---
*PR created automatically by Jules for task [18088615434472146890](https://jules.google.com/task/18088615434472146890) started by @mee1080*