### PR TITLE
Add header sorting to Ramen scenario tasting patterns table

### DIFF
--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/page/top/result/TrainingInfo.kt
@@ -27,7 +27,7 @@ import io.github.mee1080.umasim.web.components.parts.DivFlexCenter
 import io.github.mee1080.umasim.web.components.parts.HideBlock
 import io.github.mee1080.umasim.web.components.parts.NestedHideBlock
 import io.github.mee1080.umasim.web.components.parts.SliderEntry
-import io.github.mee1080.umasim.web.state.State
+import io.github.mee1080.umasim.web.state.*
 import io.github.mee1080.umasim.web.state.WebConstants
 import io.github.mee1080.umasim.web.state.WebConstants.trainingTypeList
 import io.github.mee1080.umasim.web.style.AppStyle
@@ -397,6 +397,7 @@ fun TrainingInfo(model: ViewModel, state: State) {
             })
 
             if (state.ramenAllTastingImpact.isNotEmpty()) {
+                Div { Text("※項目名クリックでソート") }
                 Div { Text("※見にくければExcelとかにコピペして") }
                 Div({ style { marginTop(16.px) } }) {
                     Table({ classes(AppStyle.table) }) {
@@ -404,7 +405,9 @@ fun TrainingInfo(model: ViewModel, state: State) {
                             Th({
                                 unsetWidth()
                                 colspan(state.supportSelectionList.count { it.card != null })
-                            }) { Text("初期配置") }
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.InitialParticipants) }
+                            }) { Text("初期配置" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.InitialParticipants)) }
                         }
                         Tr {
                             state.supportSelectionList.forEach { support ->
@@ -412,16 +415,47 @@ fun TrainingInfo(model: ViewModel, state: State) {
                                     Th({ unsetWidth() }) { Text(it.chara.first().toString()) }
                                 }
                             }
-                            Th({ unsetWidth() }) { Text("追加配置") }
-                            Th { Text("スピード") }
-                            Th { Text("スタミナ") }
-                            Th { Text("パワー") }
-                            Th { Text("根性") }
-                            Th { Text("賢さ") }
-                            Th { Text("スキルPt") }
-                            Th { Text("体力") }
-                            Th { Text("5ステ合計") }
-                            Th { Text("5ステ+SP") }
+                            Th({
+                                unsetWidth()
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.AddedChara) }
+                            }) { Text("追加配置" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.AddedChara)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.Speed) }
+                            }) { Text("スピード" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.Speed)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.Stamina) }
+                            }) { Text("スタミナ" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.Stamina)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.Power) }
+                            }) { Text("パワー" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.Power)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.Guts) }
+                            }) { Text("根性" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.Guts)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.Wisdom) }
+                            }) { Text("賢さ" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.Wisdom)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.SkillPt) }
+                            }) { Text("スキルPt" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.SkillPt)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.Hp) }
+                            }) { Text("体力" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.Hp)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.StatusTotal) }
+                            }) { Text("5ステ合計" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.StatusTotal)) }
+                            Th({
+                                style { cursor("pointer") }
+                                onClick { model.updateRamenAllTastingSort(RamenAllTastingSortKey.TotalPlusSkillPt) }
+                            }) { Text("5ステ+SP" + state.getRamenAllTastingSortIndicator(RamenAllTastingSortKey.TotalPlusSkillPt)) }
                         }
                         state.ramenAllTastingImpact.forEach { impact ->
                             Tr {

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/state/State.kt
@@ -78,6 +78,8 @@ data class State(
     val trainingImpact: List<Pair<String, Status>> = emptyList(),
     val ramenTastingImpact: List<RamenTastingImpact> = emptyList(),
     val ramenAllTastingImpact: List<RamenAllTastingImpact> = emptyList(),
+    val ramenAllTastingSortKey: RamenAllTastingSortKey? = null,
+    val ramenAllTastingSortDescending: Boolean = true,
     val expectedResult: ExpectedStatus = ExpectedStatus(),
     val upperRate: Double = 0.0,
     val friendProbability: Double = 0.0,
@@ -203,6 +205,63 @@ data class RamenAllTastingImpact(
     val added: MemberState,
     val impact: Status,
 )
+
+sealed interface RamenAllTastingSortKey {
+    object InitialParticipants : RamenAllTastingSortKey
+    object AddedChara : RamenAllTastingSortKey
+    object Speed : RamenAllTastingSortKey
+    object Stamina : RamenAllTastingSortKey
+    object Power : RamenAllTastingSortKey
+    object Guts : RamenAllTastingSortKey
+    object Wisdom : RamenAllTastingSortKey
+    object SkillPt : RamenAllTastingSortKey
+    object Hp : RamenAllTastingSortKey
+    object StatusTotal : RamenAllTastingSortKey
+    object TotalPlusSkillPt : RamenAllTastingSortKey
+}
+
+fun List<RamenAllTastingImpact>.sortRamenAllTastingImpact(
+    key: RamenAllTastingSortKey,
+    descending: Boolean
+): List<RamenAllTastingImpact> {
+    return this.sortedWith { a, b ->
+        val comparison = when (key) {
+            RamenAllTastingSortKey.InitialParticipants -> {
+                val aStr = a.participants.sorted().joinToString(",")
+                val bStr = b.participants.sorted().joinToString(",")
+                aStr.compareTo(bStr)
+            }
+            RamenAllTastingSortKey.AddedChara -> {
+                val aName = a.added.card.name
+                val bName = b.added.card.name
+                aName.compareTo(bName)
+            }
+            RamenAllTastingSortKey.Speed -> a.impact.speed.compareTo(b.impact.speed)
+            RamenAllTastingSortKey.Stamina -> a.impact.stamina.compareTo(b.impact.stamina)
+            RamenAllTastingSortKey.Power -> a.impact.power.compareTo(b.impact.power)
+            RamenAllTastingSortKey.Guts -> a.impact.guts.compareTo(b.impact.guts)
+            RamenAllTastingSortKey.Wisdom -> a.impact.wisdom.compareTo(b.impact.wisdom)
+            RamenAllTastingSortKey.SkillPt -> a.impact.skillPt.compareTo(b.impact.skillPt)
+            RamenAllTastingSortKey.Hp -> a.impact.hp.compareTo(b.impact.hp)
+            RamenAllTastingSortKey.StatusTotal -> {
+                val aTotal = a.impact.speed + a.impact.stamina + a.impact.power + a.impact.guts + a.impact.wisdom
+                val bTotal = b.impact.speed + b.impact.stamina + b.impact.power + b.impact.guts + b.impact.wisdom
+                aTotal.compareTo(bTotal)
+            }
+            RamenAllTastingSortKey.TotalPlusSkillPt -> {
+                val aTotal = a.impact.speed + a.impact.stamina + a.impact.power + a.impact.guts + a.impact.wisdom + a.impact.skillPt
+                val bTotal = b.impact.speed + b.impact.stamina + b.impact.power + b.impact.guts + b.impact.wisdom + b.impact.skillPt
+                aTotal.compareTo(bTotal)
+            }
+        }
+        if (descending) -comparison else comparison
+    }
+}
+
+fun State.getRamenAllTastingSortIndicator(key: RamenAllTastingSortKey): String {
+    if (ramenAllTastingSortKey != key) return ""
+    return if (ramenAllTastingSortDescending) " ▼" else " ▲"
+}
 
 data class SupportSelection(
     val selectedSupport: Int = WebConstants.notSelected.first,

--- a/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
+++ b/web/src/jsMain/kotlin/io/github/mee1080/umasim/web/vm/ViewModel.kt
@@ -966,11 +966,38 @@ class ViewModel(val scope: CoroutineScope, initialPage: String?) {
                     )
                 }
             }
-            results.sortByDescending { it.impact.totalPlusSkillPt }
+            val sortedResults = if (state.ramenAllTastingSortKey != null) {
+                results.sortRamenAllTastingImpact(state.ramenAllTastingSortKey, state.ramenAllTastingSortDescending)
+            } else {
+                results.sortRamenAllTastingImpact(RamenAllTastingSortKey.TotalPlusSkillPt, true)
+            }
 
             withContext(Dispatchers.Main) {
-                updateState(calculate = false) { it.copy(ramenAllTastingImpact = results) }
+                updateState(calculate = false) {
+                    it.copy(
+                        ramenAllTastingImpact = sortedResults,
+                        ramenAllTastingSortKey = it.ramenAllTastingSortKey ?: RamenAllTastingSortKey.TotalPlusSkillPt,
+                        ramenAllTastingSortDescending = it.ramenAllTastingSortDescending
+                    )
+                }
             }
+        }
+    }
+
+    fun updateRamenAllTastingSort(key: RamenAllTastingSortKey) {
+        val state = state
+        val nextDescending = if (state.ramenAllTastingSortKey == key) {
+            !state.ramenAllTastingSortDescending
+        } else {
+            true
+        }
+        val sortedList = state.ramenAllTastingImpact.sortRamenAllTastingImpact(key, nextDescending)
+        update {
+            copy(
+                ramenAllTastingImpact = sortedList,
+                ramenAllTastingSortKey = key,
+                ramenAllTastingSortDescending = nextDescending
+            )
         }
     }
 }


### PR DESCRIPTION
This pull request adds interactive column sorting to the '全パターン計算' (Calculate All Patterns) table in the Ramen scenario under the web module. Clicking column headers allows toggling between descending and ascending orders (1st click descending, 2nd click ascending) with visual indicators (▼/▲). Furthermore, the Japanese instruction '※項目名クリックでソート' has been added right before the copy-paste tooltip. All changes are strictly within the Kotlin/JS source files, keeping the `docs/` folder untouched as requested.

---
*PR created automatically by Jules for task [1432151986544640799](https://jules.google.com/task/1432151986544640799) started by @mee1080*